### PR TITLE
Add Mapbox API token to zeno API

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -147,6 +147,7 @@ jobs:
           --set secrets.api.AWS_ACCESS_KEY_ID=${{ secrets.S3_READONLY_AWS_ACCESS_KEY_ID }}
           --set secrets.api.AWS_SECRET_ACCESS_KEY=${{ secrets.S3_READONLY_AWS_SECRET_ACCESS_KEY }}
           --set secrets.api.GEE_SERVICE_ACCOUNT_JSON=${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}
+          --set secrets.api.MAPBOX_API_TOKEN=${{ secrets.MAPBOX_API_TOKEN }}
       - name: Helm Deploy Zeno Dev Instance
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: ./helm
@@ -163,3 +164,4 @@ jobs:
           --set secrets.api.AWS_ACCESS_KEY_ID=${{ secrets.S3_READONLY_AWS_ACCESS_KEY_ID }}
           --set secrets.api.AWS_SECRET_ACCESS_KEY=${{ secrets.S3_READONLY_AWS_SECRET_ACCESS_KEY }}
           --set secrets.api.GEE_SERVICE_ACCOUNT_JSON=${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}
+          --set secrets.api.MAPBOX_API_TOKEN=${{ secrets.MAPBOX_API_TOKEN }}

--- a/helm/zeno/templates/deployment.yaml
+++ b/helm/zeno/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-zeno-secrets
                   key: ANTHROPIC_API_KEY
+            - name: MAPBOX_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-zeno-secrets
+                  key: MAPBOX_API_TOKEN
             - name: LANGFUSE_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/zeno/templates/secrets.yaml
+++ b/helm/zeno/templates/secrets.yaml
@@ -18,4 +18,5 @@ data:
   ANTHROPIC_API_KEY: {{ .Values.secrets.api.ANTHROPIC_API_KEY | b64enc }}
   AWS_ACCESS_KEY_ID: {{ .Values.secrets.api.AWS_ACCESS_KEY_ID | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.secrets.api.AWS_SECRET_ACCESS_KEY | b64enc }}
+  MAPBOX_API_TOKEN: {{ .Values.secrets.api.MAPBOX_API_TOKEN | b64enc }}
   GEE_SERVICE_ACCOUNT_JSON: {{ .Values.secrets.api.GEE_SERVICE_ACCOUNT_JSON }} # already base64 encoded

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -13,6 +13,7 @@ secrets:
     AWS_ACCESS_KEY_ID:
     AWS_SECRET_ACCESS_KEY:
     GEE_SERVICE_ACCOUNT_JSON:
+    MAPBOX_API_TOKEN:
 
 langfuse:
   enabled: true


### PR DESCRIPTION
Required by: https://github.com/wri/project-zeno/pull/85 

Allows API to use Mapbox geocoding for location search tool
