### PR TITLE
Update image tag on prod

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -4,7 +4,7 @@ langfuse:
 api:
   host: api.zeno.ds.io
   image:
-    tag: 8582c04cfc6c8c77a433bea31cd640322fcb20a1
+    tag: 2757f359105a9738086f1d07ac2e8200cca9675d
   config:
     LANGFUSE_HOST: https://langfuse.zeno.ds.io
     OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -3,8 +3,6 @@ langfuse:
 
 api:
   host: api.zeno.ds.io
-  image:
-    tag: 2757f359105a9738086f1d07ac2e8200cca9675d
   config:
     LANGFUSE_HOST: https://langfuse.zeno.ds.io
     OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -4,8 +4,6 @@ langfuse:
 
 api:
   host: api.zeno-staging.ds.io
-  image:
-    tag: 2757f359105a9738086f1d07ac2e8200cca9675d
   config:
     LANGFUSE_HOST: https://langfuse.zen-staging.ds.io
     OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -5,7 +5,7 @@ langfuse:
 api:
   host: api.zeno-staging.ds.io
   image:
-    tag: 8582c04cfc6c8c77a433bea31cd640322fcb20a1
+    tag: 2757f359105a9738086f1d07ac2e8200cca9675d
   config:
     LANGFUSE_HOST: https://langfuse.zen-staging.ds.io
     OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -27,7 +27,7 @@ api:
   replicas: 1
   image:
     repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-    tag: 8582c04cfc6c8c77a433bea31cd640322fcb20a1
+    tag: 2757f359105a9738086f1d07ac2e8200cca9675d
   config:
     LANGFUSE_HOST: https://langfuse.zeno.ds.io
     OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434


### PR DESCRIPTION
Does a merge to main to update the image tag on prod so https://api.zeno.ds.io is running the latest "stable" version.

This way prod will be stable with the latest version and we can run experiments around the new deploy on staging.

@kamicut - when this PR is merged, we should be able to point the frontend to https://api.zeno.ds.io and consider that the "stable" version going forward.
