### PR TITLE
add DOMAINS_ALLOWLIST to config

### DIFF
--- a/helm/zeno/templates/deployment.yaml
+++ b/helm/zeno/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
               value: /keys/zeno-gee-service-account.json
             - name: OLLAMA_BASE_URL
               value: {{ .Values.api.config.OLLAMA_BASE_URL }}
+            - name: DOMAINS_ALLOWLIST
+              value: {{ .Values.api.config.DOMAINS_ALLOWLIST | quote }}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -31,6 +31,7 @@ api:
   config:
     LANGFUSE_HOST: https://langfuse.zeno.ds.io
     OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434
+    DOMAINS_ALLOWLIST: "developmentseed.org,wri.org,wriconsultant.org"
 
 streamlit:
   host: streamlit.zeno.ds.io


### PR DESCRIPTION
Adds the DOMAINS_ALLOWLIST environment variable on the API container.

This should have been done as part of https://github.com/wri/project-zeno-deploy/issues/16 but I missed this one.

cc @sunu @leothomas 