### PR TITLE
Fixed #33, create a k8s secret object for eoapi db credentials

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -198,29 +198,12 @@ jobs:
         if: |
           github.event_name == 'push' && 
           (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-        working-directory: ./terraform
-        run: |
-          echo "Getting DB host..."
-          # Store and parse the output
-          DB_OUTPUT=$(terraform output -raw eoapi_db_endpoint)
-          echo "Raw output: $DB_OUTPUT"
-          
-          # Extract just the hostname using grep pattern and take first match
-          EOAPI_DB_HOST=$(echo "$DB_OUTPUT" | grep -o 'eoapi-[^:]*' | head -n1 || echo '')
-          echo "Clean hostname: $EOAPI_DB_HOST"
-          
-          if [ -z "$EOAPI_DB_HOST" ]; then
-            echo "Error: Failed to get DB host!"
-            exit 1
-          fi
-          
-          cd ..
-          helm upgrade --install \
-            eoapi \
-            eoapi/eoapi \
-            -f helm/eoapi/values.yaml \
-            -f helm/eoapi/values-${{ env.ENVIRONMENT }}.yaml \
-            --set postgresql.external.credentials.password="${{ secrets.EOAPI_DB_PASSWORD }}" \
-            --set postgresql.external.host="$EOAPI_DB_HOST" \
-            --namespace eoapi \
-            --create-namespace
+        working-directory: ./helm
+        run: >
+          helm upgrade --install 
+          eoapi
+          eoapi/eoapi
+          -f eoapi/values.yaml
+          -f eoapi/values-${{ env.ENVIRONMENT }}.yaml
+          --namespace eoapi
+          --create-namespace

--- a/helm/eoapi/values-production.yaml
+++ b/helm/eoapi/values-production.yaml
@@ -1,11 +1,3 @@
-postgresql:
-  type: "external-plaintext"
-  external:
-    port: "5432"
-    database: "eoapi"
-    credentials:
-      username: "eoapi"
-
 ingress:
   host: "eoapi.zeno.ds.io"
 

--- a/helm/eoapi/values-staging.yaml
+++ b/helm/eoapi/values-staging.yaml
@@ -1,11 +1,3 @@
-postgresql:
-  type: "external-plaintext"
-  external:
-    port: "5432"
-    database: "eoapi"
-    credentials:
-      username: "eoapi"
-
 ingress:
   host: "eoapi.zeno-staging.ds.io"
 

--- a/helm/eoapi/values.yaml
+++ b/helm/eoapi/values.yaml
@@ -1,11 +1,8 @@
 # Default configuration for eoapi
 postgresql:
-  type: "external-plaintext"
+  type: "external-secret"
   external:
-    port: "5432"
-    database: "eoapi"
-    credentials:
-      username: "eoapi"
+    secretName: "eoapi-db-credentials"
 
 postgrescluster:
   enabled: false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,7 +6,3 @@ module "resources" {
     eoapi_db_password = var.eoapi_db_password
 }
 
-output "eoapi_db_endpoint" {
-    description = "The endpoint of the eoapi RDS instance"
-    value = module.resources.eoapi_db_endpoint
-}

--- a/terraform/resources/rds.tf
+++ b/terraform/resources/rds.tf
@@ -78,11 +78,18 @@ resource "aws_db_subnet_group" "eoapi" {
   }
 }
 
-# Add outputs for the database endpoint and name
-output "eoapi_db_endpoint" {
-  value = aws_db_instance.eoapi.endpoint
-}
+# Create Kubernetes secret for database credentials
+resource "kubernetes_secret" "eoapi_db_credentials" {
+  metadata {
+    name      = "eoapi-db-credentials"
+    namespace = "eoapi"
+  }
 
-output "eoapi_db_name" {
-  value = aws_db_instance.eoapi.db_name
+  data = {
+    username = "eoapi"
+    password = var.eoapi_db_password
+    host     = split(":", aws_db_instance.eoapi.endpoint)[0]
+    port     = "5432"
+    database = "eoapi"
+  }
 }

--- a/terraform/resources/rds.tf
+++ b/terraform/resources/rds.tf
@@ -85,7 +85,7 @@ resource "kubernetes_secret" "eoapi_db_credentials" {
     namespace = "eoapi"
   }
 
-  data = {
+  stringData = {
     username = "eoapi"
     password = var.eoapi_db_password
     host     = split(":", aws_db_instance.eoapi.endpoint)[0]

--- a/terraform/resources/rds.tf
+++ b/terraform/resources/rds.tf
@@ -85,7 +85,7 @@ resource "kubernetes_secret" "eoapi_db_credentials" {
     namespace = "eoapi"
   }
 
-  stringData = {
+  data = {
     username = "eoapi"
     password = var.eoapi_db_password
     host     = split(":", aws_db_instance.eoapi.endpoint)[0]


### PR DESCRIPTION
Create a k8s Secret object as part of the Terraform apply step with the db credentials and then use that in the eoapi setup instead of passing db creds via `--set` in the deploy and having to do the weird munging of the terraform outputs.
