### PR TITLE
pin version of eoAPI being installed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -203,6 +203,7 @@ jobs:
           helm upgrade --install 
           eoapi
           eoapi/eoapi
+          --version 0.7.0
           -f eoapi/values.yaml
           -f eoapi/values-${{ env.ENVIRONMENT }}.yaml
           --namespace eoapi


### PR DESCRIPTION
Pin version of eoAPI being installed to 0.7.0 to not get unexpected upstream changes when deploying.

(going ahead with the merge, just cc @sunu for visibility)