### PR TITLE
set nginx proxy body size for API ingress to 100m

### DIFF
--- a/helm/zeno/templates/ingress.yaml
+++ b/helm/zeno/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   {{- if .Values.zeno.config.enable_tls }}


### PR DESCRIPTION
Increase nginx proxy-body-size in the ingress config due to `413 Request Entity Too Large` errors.

