### PR TITLE
set the default ingress max proxy body size to 500m

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -123,6 +123,7 @@ jobs:
           --version 4.11.3
           --namespace ingress-nginx
           --create-namespace
+          --set controller.config.proxy-body-size=500m
 
       # Deploy cert-manager
       - name: Deploy cert-manager

--- a/helm/zeno/templates/ingress.yaml
+++ b/helm/zeno/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   {{- if .Values.zeno.config.enable_tls }}


### PR DESCRIPTION
Set the ingress default size to apply to all the ingress nginx and up proxy-body-size to 500mb to try and tackle Request Entity Too Large errors.