### PR TITLE
add basic instructions on seeing logs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,20 @@ db:
 ```
 
 Note: It's important to ensure that the database migrations are compatible with the application version being deployed.
+
+### Inspecting Logs
+
+We use Prometheus + Loki + Grafana for monitoring of services and logging.
+
+To login:
+
+Go to https://grafana.zeno-staging.ds.io
+
+Login: admin
+Get password with `kubectl get secret -n support support-grafana -o jsonpath='{.data.admin-password}' | base64 -d`
+
+To get memory, CPU usage, etc. over time for pods, go to Dashboard and select the appropriate Dashboard.
+
+To see API logs:
+
+Go to Explore. Switch from Prometheus to Loki in the top bar. In label filters: select label=component and value=api . Hit the Run Query button at the top right. You should see the raw logs appear below. You can use the text filter to narrow down your search.


### PR DESCRIPTION
Adds basic instructions to the README on viewing logs and monitoring CPU / RAM usage in Grafana.

We probably want to move to adding structured logs, and we can create some dashboards in Grafana to make this a bit more convenient, but this should work to document what works right now.

@sunu - I've added the `kubectl` command to get the secret - is this something we could put in 1password or does this secret change?

cc @yellowcap 
