### PR TITLE
bump api replicas to 3

### DIFF
--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -132,7 +132,7 @@ zeno:
 
   api:
     host: api.zeno.ds.io
-    replicas: 1
+    replicas: 3
     resources:
       requests:
         cpu: "1000m"


### PR DESCRIPTION
Bumps the number of replicas of the API container to 3. Should help with stability issues for now. We should revisit the config once we've fixed async issues in the API and can do more proper resource evaluation.

We will eventually want to have different values for staging and production, we can do this easily down the line.

cc @sunu 
