### PR TITLE
update api and db images, make DATABASE_URL use asyncpg

### DIFF
--- a/helm/zeno/templates/secrets.yaml
+++ b/helm/zeno/templates/secrets.yaml
@@ -26,4 +26,4 @@ data:
   GFW_DATA_API_KEY: {{ .Values.zeno.secrets.api.GFW_DATA_API_KEY | default "" | b64enc }}
   GFW_DATA_API_USER_ID: {{ .Values.zeno.secrets.api.GFW_DATA_API_USER_ID | default "" | b64enc }}
   COOKIE_SIGNER_SECRET_KEY: {{ .Values.zeno.secrets.api.COOKIE_SIGNER_SECRET_KEY | b64enc }}
-  DATABASE_URL: {{ printf "postgresql+psycopg://%s:%s@%s/%s" (.Values.zeno.db.POSTGRES_USER | default "") (.Values.zeno.db.POSTGRES_PASSWORD | default "") (.Values.zeno.db.POSTGRES_HOST | default "") (.Values.zeno.db.APP_DB | default "") | b64enc }}
+  DATABASE_URL: {{ printf "postgresql+asyncpg://%s:%s@%s/%s" (.Values.zeno.db.POSTGRES_USER | default "") (.Values.zeno.db.POSTGRES_PASSWORD | default "") (.Values.zeno.db.POSTGRES_HOST | default "") (.Values.zeno.db.APP_DB | default "") | b64enc }}

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -142,7 +142,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 840e3bf1bf294d10a696a01a1403cd0cf6ba9184
+      tag: d1fa926978017112b87c900ffd7b0f68c082b7c4
     config:
       LOG_FORMAT: json
       LOG_LEVEL: info
@@ -169,4 +169,4 @@ zeno:
     POSTGRES_DB: zeno_db
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-      tag: e7f039a9e52e49184c8a546f66d1c45d637707e0
+      tag: 4aefad53c3cd58998ecb4483dd6445bc3fd07ea0


### PR DESCRIPTION
Updates API and db image tags.

Importantly, converts the DATABASE_URL to use `asyncpg` instead of `psycopg2`.

cc @willemarcel @sunu 