### PR TITLE
reduce resource requirements and replicas on API to test performance

### DIFF
--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -133,13 +133,13 @@ zeno:
 
   api:
     host: api.zeno.ds.io
-    replicas: 3
+    replicas: 1
     resources:
       requests:
         cpu: "1000m"
-        memory: "2Gi"
+        memory: "1Gi"
       limits:
-        memory: "4Gi"
+        memory: "2Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
       tag: 987b4136498b183480616bc2b325b1d9462ceb0b


### PR DESCRIPTION
With the new API changes to move to async everywhere as well as moving geometry search to the database, our memory requirements should have gotten lower, and we should be able to handle parallel requests a lot better.

I've bumped down the RAM usage as well as reduced replicas to 1 in this PR. I'd like to test how things work at this level, and then bump up only if actually needed. Eventually, of course, we'll run at least 2 containers, but it would be good to get a sense of how this performs to get a better sense of what we will need to handle larger volumes. 

cc @sunu 