### PR TITLE
up clickhouse volume size to 20GB

### DIFF
--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -69,6 +69,7 @@ langfuse:
   clickhouse:
     persistence:
       storageClass: "gp2"
+      size: "20Gi"
     zookeeper:
       persistence:
         storageClass: "gp2"


### PR DESCRIPTION
increase storage size for now to get langfuse traces to work, then we will debug how to ensure size does not grow indefinitely.

cc @sunu 