### PR TITLE
Allow TiTiler to make requester pays requests to s3

### DIFF
--- a/helm/eoapi/values.yaml
+++ b/helm/eoapi/values.yaml
@@ -1,4 +1,12 @@
 # Default configuration for eoapi
+raster:
+  settings:
+    envVars:
+      AWS_REQUEST_PAYER: "requester"
+    extraEnvFrom:
+      - secretRef:
+          name: requester-pays-s3-credentials
+
 postgresql:
   type: "external-secret"
   external:

--- a/terraform/resources/outputs.tf
+++ b/terraform/resources/outputs.tf
@@ -17,3 +17,14 @@ output "cluster_name" {
   description = "Kubernetes Cluster Name"
   value = module.eks.cluster_name
 }
+
+output "requester_pays_access_key_id" {
+  description = "Access Key ID for requester pays S3 access"
+  value = aws_iam_access_key.requester_pays.id
+}
+
+output "requester_pays_secret_key" {
+  description = "Secret Access Key for requester pays S3 access"
+  value = aws_iam_access_key.requester_pays.secret
+  sensitive = true
+}

--- a/terraform/resources/requester-pays-s3.tf
+++ b/terraform/resources/requester-pays-s3.tf
@@ -62,13 +62,3 @@ resource "kubernetes_secret" "requester_pays_s3_credentials" {
     AWS_SECRET_ACCESS_KEY = aws_iam_access_key.requester_pays.secret
   }
 }
-
-# Outputs
-output "requester_pays_access_key_id" {
-  value = aws_iam_access_key.requester_pays.id
-}
-
-output "requester_pays_secret_key" {
-  value     = aws_iam_access_key.requester_pays.secret
-  sensitive = true
-}

--- a/terraform/resources/requester-pays-s3.tf
+++ b/terraform/resources/requester-pays-s3.tf
@@ -60,8 +60,8 @@ resource "kubernetes_secret" "requester_pays_s3_credentials" {
   }
 
   data = {
-    access_key_id     = aws_iam_access_key.requester_pays.id
-    secret_access_key = aws_iam_access_key.requester_pays.secret
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.requester_pays.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.requester_pays.secret
   }
 }
 

--- a/terraform/resources/requester-pays-s3.tf
+++ b/terraform/resources/requester-pays-s3.tf
@@ -17,9 +17,8 @@ resource "aws_iam_user_policy" "requester_pays" {
           "s3:GetObject"
         ]
         Resource = [
-          # Replace with the specific external requester pays buckets you need access to
-          # Example: "arn:aws:s3:::landsat-pds/*",
-          # Example: "arn:aws:s3:::sentinel-s2-l2a/*"
+          "arn:aws:s3:::lcl-cogs/*",
+          "arn:aws:s3:::gfw-data-lake/*"
         ]
         Condition = {
           StringEquals = {
@@ -33,9 +32,8 @@ resource "aws_iam_user_policy" "requester_pays" {
           "s3:ListBucket"
         ]
         Resource = [
-          # Replace with the specific external requester pays buckets you need access to
-          # Example: "arn:aws:s3:::landsat-pds",
-          # Example: "arn:aws:s3:::sentinel-s2-l2a"
+          "arn:aws:s3:::lcl-cogs",
+          "arn:aws:s3:::gfw-data-lake"
         ]
         Condition = {
           StringEquals = {


### PR DESCRIPTION
This:

 - Creates a Terraform resource with an IAM role
 - Puts the access key and secret access key for that role into a kubernetes secret
 - References values from that secret in the eoapi values.yaml file to set as env vars in titiler

Am a bit unsure if referencing the secret with this `extraEnvFrom` - `secretRef` stuff actually works. cc @ciaransweet 

@yellowcap once you give me a starting list of buckets this should have access to, we can try deploying and seeing what happens.