### PR TITLE
add cluster autoscaler based on suggestion for simplified iam role creation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -140,6 +140,21 @@ jobs:
           --create-namespace
           --set installCRDs=true
 
+      # Deploy cluster-autoscaler
+      - name: Deploy cluster-autoscaler
+        if: |
+          github.event_name == 'push' && 
+          (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+        run: |
+          ROLE_ARN=$(cd terraform && terraform output -raw cluster_autoscaler_iam_role_arn)
+          echo "Cluster Autoscaler IAM Role ARN: ${ROLE_ARN}"
+          helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler \
+            --version 9.43.0 \
+            -f helm/cluster-autoscaler/values.yaml \
+            -f helm/cluster-autoscaler/values-${{ env.ENVIRONMENT }}.yaml \
+            --set-string 'serviceAccount.annotations.eks\.amazonaws\.com/role-arn'="${ROLE_ARN}" \
+            --namespace kube-system
+
       # Update dependencies for monitoring
       - name: Update Helm Dependencies for monitoring
         if: |

--- a/helm/cluster-autoscaler/values-production.yaml
+++ b/helm/cluster-autoscaler/values-production.yaml
@@ -1,0 +1,5 @@
+autoDiscovery:
+  clusterName: zeno-production-cluster
+
+extraArgs:
+  node-group-auto-discovery: asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/zeno-production-cluster

--- a/helm/cluster-autoscaler/values-staging.yaml
+++ b/helm/cluster-autoscaler/values-staging.yaml
@@ -1,0 +1,5 @@
+autoDiscovery:
+  clusterName: zeno-staging-cluster
+
+extraArgs:
+  node-group-auto-discovery: asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/zeno-staging-cluster

--- a/helm/cluster-autoscaler/values.yaml
+++ b/helm/cluster-autoscaler/values.yaml
@@ -1,0 +1,21 @@
+# Cluster Autoscaler Helm values
+autoDiscovery:
+  clusterName: zeno-cluster  # Will be overridden per environment
+
+awsRegion: us-east-1
+
+serviceAccount:
+  create: true
+  name: cluster-autoscaler
+  # Role ARN will be set via --set-string in GitHub Actions
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 300Mi
+
+extraArgs:
+  # node-group-auto-discovery will be overridden in environment-specific values files

--- a/terraform/resources/cluster-autoscaler.tf
+++ b/terraform/resources/cluster-autoscaler.tf
@@ -1,6 +1,7 @@
 # Simple version using the EKS IAM module
 module "cluster_autoscaler_irsa" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${local.cluster_name}-cluster-autoscaler"
 

--- a/terraform/resources/cluster-autoscaler.tf
+++ b/terraform/resources/cluster-autoscaler.tf
@@ -1,0 +1,22 @@
+# Simple version using the EKS IAM module
+module "cluster_autoscaler_irsa" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+
+  role_name = "${local.cluster_name}-cluster-autoscaler"
+
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_names = [local.cluster_name]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cluster-autoscaler"]
+    }
+  }
+}
+
+# Output for Helm
+output "cluster_autoscaler_iam_role_arn" {
+  description = "ARN of the IAM role for cluster autoscaler"
+  value       = module.cluster_autoscaler_irsa.iam_role_arn
+}


### PR DESCRIPTION
Adds back cluster autoscaler based on @sunu's suggestion for simplified IAM role handling.

Likely still going to have issues, but I'll just merge this and then debug the silly setting of the role ARN correctly during the helm install.

