### PR TITLE
Enable horizontal pod autoscaling; tweak default resource allocations

### DIFF
--- a/helm/zeno/templates/hpa.yaml
+++ b/helm/zeno/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.zeno.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-api-hpa
+  labels:
+    app: zeno
+    component: api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-api
+  minReplicas: {{ .Values.zeno.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.zeno.api.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.zeno.api.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.zeno.api.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -17,25 +17,24 @@ zeno:
 
   api:
     host: api.zeno.ds.io
+    autoscaling:
+      enabled: true
+      minReplicas: 3
+      maxReplicas: 15
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
     resources:
       requests:
         cpu: "1000m"
-        memory: "4Gi"
+        memory: "2Gi"
       limits:
-        memory: "6Gi"
+        memory: "4Gi"
     config:
       LANGFUSE_HOST: https://langfuse.zeno.ds.io
       OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434
 
   streamlit:
     host: streamlit.zeno.ds.io
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "1Gi"
-      limits:
-        cpu: "1000m"
-        memory: "2Gi"
     config:
       API_BASE_URL: https://api.zeno.ds.io
       STREAMLIT_URL: https://streamlit.zeno.ds.io

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -21,25 +21,24 @@ zeno:
 
   api:
     host: api.zeno-staging.ds.io
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
     resources:
       requests:
         cpu: "1000m"
-        memory: "3Gi"
+        memory: "2Gi"
       limits:
-        memory: "6Gi"
+        memory: "4Gi"
     config:
       LANGFUSE_HOST: https://langfuse.zeno-staging.ds.io
       OLLAMA_BASE_URL: http://ollama.default.svc.cluster.local:11434
 
   streamlit:
     host: streamlit.zeno-staging.ds.io
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "1Gi"
-      limits:
-        cpu: "1500m"
-        memory: "2Gi"
     config:
       API_BASE_URL: https://api.zeno-staging.ds.io
       STREAMLIT_URL: https://streamlit.zeno-staging.ds.io

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -75,6 +75,7 @@ langfuse:
     auth:
       existingSecret: zeno-langfuse-secrets
       existingSecretKey: CLICKHOUSE_PASSWORD
+    resourcesPreset: medium
   redis:
     primary:
       persistence:
@@ -135,6 +136,12 @@ zeno:
   api:
     host: api.zeno.ds.io
     replicas: 2
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
     resources:
       requests:
         cpu: "1000m"
@@ -155,11 +162,11 @@ zeno:
     host: streamlit.zeno.ds.io
     resources:
       requests:
+        cpu: "100m"
+        memory: "0.2Gi"
+      limits:
         cpu: "500m"
         memory: "1Gi"
-      limits:
-        cpu: "1000m"
-        memory: "2Gi"
     config:
       API_BASE_URL: https://api.zeno.ds.io
 


### PR DESCRIPTION
Enables autoscaling of zeno-api pods based on CPU and memory usage.

From a quick look at resource utilization, looks like our nodes are very under utilized at the moment:

```
$ kubectl resource-capacity -n default --pods --util
NODE                         POD                              CPU REQUESTS   CPU LIMITS     CPU UTIL    MEMORY REQUESTS   MEMORY LIMITS   MEMORY UTIL
*                            *                                6350m (26%)    20775m (87%)   0m (0%)     17280Mi (18%)     52544Mi (57%)   0Mi (0%)

ip-10-0-1-14.ec2.internal    *                                2250m (28%)    6375m (80%)    77m (0%)    6400Mi (20%)      18816Mi (61%)   2230Mi (7%)
ip-10-0-1-14.ec2.internal    zeno-api-5c77654d8c-rz5x6        1000m (12%)    0m (0%)        1m (0%)     3072Mi (9%)       6144Mi (19%)    296Mi (0%)
ip-10-0-1-14.ec2.internal    zeno-clickhouse-shard0-1         1000m (12%)    6000m (75%)    49m (0%)    3072Mi (9%)       12288Mi (39%)   1124Mi (3%)
ip-10-0-1-14.ec2.internal    zeno-web-68b4c76d79-zp9gg        0m (0%)        0m (0%)        2m (0%)     0Mi (0%)          0Mi (0%)        292Mi (0%)
ip-10-0-1-14.ec2.internal    zeno-worker-864c4699b9-57wfv     0m (0%)        0m (0%)        19m (0%)    0Mi (0%)          0Mi (0%)        140Mi (0%)
ip-10-0-1-14.ec2.internal    zeno-zookeeper-2                 250m (3%)      375m (4%)      7m (0%)     256Mi (0%)        384Mi (1%)      380Mi (1%)

ip-10-0-2-230.ec2.internal   *                                1850m (23%)    8025m (101%)   106m (1%)   4480Mi (14%)      14912Mi (48%)   1538Mi (5%)
ip-10-0-2-230.ec2.internal   zeno-clickhouse-shard0-2         1000m (12%)    6000m (75%)    83m (1%)    3072Mi (9%)       12288Mi (39%)   1120Mi (3%)
ip-10-0-2-230.ec2.internal   zeno-ollama-6bdcb56bcd-qwnrv     0m (0%)        0m (0%)        1m (0%)     0Mi (0%)          0Mi (0%)        9Mi (0%)
ip-10-0-2-230.ec2.internal   zeno-redis-primary-0             100m (1%)      150m (1%)      13m (0%)    128Mi (0%)        192Mi (0%)      10Mi (0%)
ip-10-0-2-230.ec2.internal   zeno-streamlit-d4b5cdf79-c5xg7   500m (6%)      1500m (18%)    0m (0%)     1024Mi (3%)       2048Mi (6%)     62Mi (0%)
ip-10-0-2-230.ec2.internal   zeno-zookeeper-1                 250m (3%)      375m (4%)      11m (0%)    256Mi (0%)        384Mi (1%)      340Mi (1%)

ip-10-0-3-127.ec2.internal   *                                2250m (28%)    6375m (80%)    111m (1%)   6400Mi (20%)      18816Mi (61%)   1861Mi (6%)
ip-10-0-3-127.ec2.internal   ollama-5bb4c54686-lgbq4          0m (0%)        0m (0%)        3m (0%)     0Mi (0%)          0Mi (0%)        11Mi (0%)
ip-10-0-3-127.ec2.internal   zeno-api-5c77654d8c-shrvb        1000m (12%)    0m (0%)        1m (0%)     3072Mi (9%)       6144Mi (19%)    270Mi (0%)
ip-10-0-3-127.ec2.internal   zeno-clickhouse-shard0-0         1000m (12%)    6000m (75%)    99m (1%)    3072Mi (9%)       12288Mi (39%)   1201Mi (3%)
ip-10-0-3-127.ec2.internal   zeno-zookeeper-0                 250m (3%)      375m (4%)      9m (0%)     256Mi (0%)        384Mi (1%)      380Mi (1%)
```

So I'm also tweaking resource allocations a bit to make sure we are not over-provisioning resources too much. zeno-api still has plenty of head room and can also scale horizontally with the HPA now.

We will run VPA in recommendation mode or use `Goldilocks` to get a more accurate estimate for resource allocation in the future.