### PR TITLE
add GOOGLE_API_KEY to env

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -217,6 +217,7 @@ jobs:
           --set zeno.secrets.api.GFW_DATA_API_KEY="${{ secrets.GFW_DATA_API_KEY }}"
           --set zeno.secrets.api.GFW_DATA_API_USER_ID="${{ secrets.GFW_DATA_API_USER_ID }}"
           --set zeno.secrets.api.ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"
+          --set zeno.secrets.api.GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}"
           --set zeno.secrets.api.COOKIE_SIGNER_SECRET_KEY="${{ secrets.COOKIE_SIGNER_SECRET_KEY }}"
           --set zeno.db.POSTGRES_PASSWORD="${{ secrets.DATABASE_PASSWORD }}"
       # Deploy eoapi

--- a/helm/zeno/templates/deployment.yaml
+++ b/helm/zeno/templates/deployment.yaml
@@ -97,6 +97,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-zeno-secrets
                   key: ELEVENLABS_API_KEY
+            - name: GOOGLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-zeno-secrets
+                  key: GOOGLE_API_KEY
             - name: COOKIE_SIGNER_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -280,6 +285,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-zeno-secrets
                   key: ELEVENLABS_API_KEY
+            - name: GOOGLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-zeno-secrets
+                  key: GOOGLE_API_KEY
             - name: COOKIE_SIGNER_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/zeno/templates/secrets.yaml
+++ b/helm/zeno/templates/secrets.yaml
@@ -23,6 +23,7 @@ data:
   AWS_SECRET_ACCESS_KEY: {{ .Values.zeno.secrets.api.AWS_SECRET_ACCESS_KEY | default "" | b64enc }}
   MAPBOX_API_TOKEN: {{ .Values.zeno.secrets.api.MAPBOX_API_TOKEN | default "" | b64enc }}
   ELEVENLABS_API_KEY: {{ .Values.zeno.secrets.api.ELEVENLABS_API_KEY | default "" | b64enc }}
+  GOOGLE_API_KEY: {{ .Values.zeno.secrets.api.GOOGLE_API_KEY | default "" | b64enc }}
   GEE_SERVICE_ACCOUNT_JSON: {{ .Values.zeno.secrets.api.GEE_SERVICE_ACCOUNT_JSON | default "" }} # already base64 encoded
   GFW_DATA_API_KEY: {{ .Values.zeno.secrets.api.GFW_DATA_API_KEY | default "" | b64enc }}
   GFW_DATA_API_USER_ID: {{ .Values.zeno.secrets.api.GFW_DATA_API_USER_ID | default "" | b64enc }}

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -133,6 +133,7 @@ zeno:
       GFW_DATA_API_KEY:
       GFW_DATA_API_USER_ID:
       ELEVENLABS_API_KEY:
+      GOOGLE_API_KEY:
       COOKIE_SIGNER_SECRET_KEY:
 
   langfuse:


### PR DESCRIPTION
Adds GOOGLE_API_KEY as an env var, coming from secrets.

Needed when we merge https://github.com/wri/project-zeno/pull/379 - ideally we'd just merge that and add those image tags to this PR.

cc @srmsoumya @sunu 