### PR TITLE
Gemini for agent in production

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -34,8 +34,6 @@ zeno:
     LANGFUSE_HOST: https://langfuse.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache.globalnaturewatch.org
     DATASET_EMBEDDINGS_DB: zeno-docs-openai-index-v3
-    MODEL: "gemini"
-    SMALL_MODEL: "gemini-flash"
 
   streamlit:
     host: streamlit.globalnaturewatch.org

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -37,8 +37,6 @@ zeno:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org
     DB_MAX_OVERFLOW: "100"
-    MODEL: "gemini"
-    SMALL_MODEL: "gemini-flash"
 
   streamlit:
     host: streamlit.staging.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -155,8 +155,8 @@ zeno:
     DOMAINS_ALLOWLIST: "developmentseed.org,wri.org,wriconsultant.org,bezosearthfund.org"
     AWS_DEFAULT_REGION: us-east-1
     GEE_SERVICE_ACCOUNT_PATH: /keys/zeno-gee-service-account.json
-    MODEL: "sonnet"
-    SMALL_MODEL: "haiku"
+    MODEL: "gemini"
+    SMALL_MODEL: "gemini-flash"
     ALLOW_ANONYMOUS_CHAT: "false"
     ADMIN_USER_DAILY_QUOTA: 9999
     REGULAR_USER_DAILY_QUOTA: 10


### PR DESCRIPTION
Use gemini for agent as well. The previous deploy only enabled it on the tool level (for generating insights)