### PR TITLE
update config for prod to allow public signups

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -37,7 +37,7 @@ zeno:
     ALLOW_PUBLIC_SIGNUPS: true
     ALLOW_ANONYMOUS_CHAT: false
     DOMAINS_ALLOWLIST: ""
-    MAX_USER_SIGNUPS: 1000
+    MAX_USER_SIGNUPS: 5000
 
   streamlit:
     host: streamlit.globalnaturewatch.org


### PR DESCRIPTION
Add config to allow public signups, as per https://github.com/wri/project-zeno/blob/main/docs/DEPLOYMENT_PHASES.md

We will do this only on prod, and for staging keep it restricted to the allowed domains.

TODO: Figure out sensible number for the max users value

cc @sunu 