### PR TITLE
Remove dataset embeddings db setting

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -33,7 +33,6 @@ zeno:
   env_config:
     LANGFUSE_HOST: https://langfuse.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache.globalnaturewatch.org
-    DATASET_EMBEDDINGS_DB: zeno-docs-openai-index-v3
     ALLOW_PUBLIC_SIGNUPS: true
     ALLOW_ANONYMOUS_CHAT: false
     DOMAINS_ALLOWLIST: ""


### PR DESCRIPTION
This was still pointing production to openai embeddings. So dataset selection was not working properly since last week when we switched to gemini embeddings here https://github.com/wri/project-zeno/pull/535


