### PR TITLE
Ephemeral environment

### DIFF
--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -89,7 +89,8 @@ jobs:
         run: |
           echo "Terraform plan failed. See above for error details."
           exit 1
-            - name: Terraform Apply
+
+      - name: Terraform Apply
         working-directory: ./terraform
         run: >
           terraform apply
@@ -201,4 +202,3 @@ jobs:
           --set-string zeno.streamlit.env_config.API_BASE_URL="https://${{ env.API_HOST }}"
           --set-string zeno.streamlit.env_config.LOCAL_API_BASE_URL="https://${{ env.API_HOST }}"
           --set-string zeno.streamlit.env_config.STREAMLIT_URL="https://${{ env.STREAMLIT_HOST }}"
-

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -10,8 +10,6 @@ jobs:
   deploy:
     name: 'Deploy Ephemeral Environment'
     runs-on: ubuntu-latest
-    # Reuse the staging GitHub environment for approvals and secrets while
-    # passing a distinct ENVIRONMENT value into Terraform and Helm.
     environment: staging
     concurrency:
       group: deploy-ephemeral-${{ github.ref_name }}
@@ -20,7 +18,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: us-east-1
-      STAGING_DB_HOST: zeno-db-staging.cv2oy6g4svaz.us-east-1.rds.amazonaws.com
 
     steps:
       - name: Checkout
@@ -91,3 +88,4 @@ jobs:
         run: |
           echo "Terraform plan failed. See above for error details."
           exit 1
+

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -30,7 +30,10 @@ jobs:
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
 
-          NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:40}"
+          # Keep this short enough for downstream AWS name_prefix constraints.
+          # EKS derives names like zeno-<env>-cluster-cluster- and AWS caps
+          # some name_prefix values at 38 chars, leaving 16 chars for <env>.
+          NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:16}"
           NORMALIZED_ENVIRONMENT=$(echo "${NORMALIZED_ENVIRONMENT}" | sed -E 's/^-+//; s/-+$//')
 
           if [ -z "${NORMALIZED_ENVIRONMENT}" ]; then
@@ -88,4 +91,3 @@ jobs:
         run: |
           echo "Terraform plan failed. See above for error details."
           exit 1
-

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -80,3 +80,9 @@ jobs:
       - name: Terraform Validate
         working-directory: ./terraform
         run: terraform validate -no-color
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: |
+          echo "Terraform plan failed. See above for error details."
+          exit 1

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -1,29 +1,10 @@
 name: 'Deploy Ephemeral Environment'
 
 on:
-  workflow_dispatch:
-    inputs:
-      environment_name:
-        description: 'Name for the ephemeral environment. This will be sanitized and used for Terraform resource names.'
-        required: true
-        type: string
-      zeno_api_sha:
-        description: 'Image SHA/tag for the Zeno API image. This same image is also used by streamlit and shell.'
-        required: true
-        type: string
-      frontend_sha:
-        description: 'Optional frontend image SHA/tag. The current chart reuses the API image, so this must be blank or match zeno_api_sha.'
-        required: false
-        default: ''
-        type: string
-      zeno_db_sha:
-        description: 'Image SHA/tag for the Zeno DB migration image.'
-        required: true
-        type: string
-      eoapi_git_sha:
-        description: 'gitSha override for the eoapi chart.'
-        required: true
-        type: string
+  push:
+    branches-ignore:
+      - main
+      - develop
 
 jobs:
   deploy:
@@ -33,7 +14,7 @@ jobs:
     # passing a distinct ENVIRONMENT value into Terraform and Helm.
     environment: staging
     concurrency:
-      group: deploy-ephemeral-${{ github.event.inputs.environment_name }}
+      group: deploy-ephemeral-${{ github.ref_name }}
       cancel-in-progress: false
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -47,7 +28,7 @@ jobs:
 
       - name: Normalize environment name
         run: |
-          RAW_ENVIRONMENT="${{ inputs.environment_name }}"
+          RAW_ENVIRONMENT="${{ github.ref_name }}"
           NORMALIZED_ENVIRONMENT=$(echo "${RAW_ENVIRONMENT}" \
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
@@ -71,17 +52,6 @@ jobs:
           echo "EOAPI_HOST=eoapi-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
           echo "EOAPI_CACHE_HOST=eoapi-cache-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
           echo "GRAFANA_HOST=grafana-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
-
-      - name: Validate image input compatibility
-        run: |
-          FRONTEND_SHA="${{ inputs.frontend_sha }}"
-          API_SHA="${{ inputs.zeno_api_sha }}"
-
-          if [ -n "${FRONTEND_SHA}" ] && [ "${FRONTEND_SHA}" != "${API_SHA}" ]; then
-            echo "frontend_sha must be blank or match zeno_api_sha."
-            echo "The current Helm chart deploys API, streamlit, and shell from the same image tag."
-            exit 1
-          fi
 
       - name: Configure Kubectl
         uses: azure/setup-kubectl@v3
@@ -110,134 +80,3 @@ jobs:
       - name: Terraform Validate
         working-directory: ./terraform
         run: terraform validate -no-color
-
-      - name: Terraform Apply
-        working-directory: ./terraform
-        run: >
-          terraform apply
-          -var="environment=${{ env.ENVIRONMENT }}"
-          -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}"
-          -auto-approve
-
-      - name: Configure kubeconfig
-        run: aws eks update-kubeconfig --region "${{ env.AWS_REGION }}" --name "${{ env.CLUSTER_NAME }}"
-
-      - name: Add Helm repositories
-        run: |
-          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-          helm repo add jetstack https://charts.jetstack.io
-          helm repo add eoapi https://devseed.com/eoapi-k8s/
-          helm repo add autoscaler https://kubernetes.github.io/autoscaler
-          helm repo update
-
-      - name: Deploy ingress-nginx
-        run: >
-          helm upgrade --install
-          ingress-nginx
-          ingress-nginx/ingress-nginx
-          --version 4.11.3
-          --namespace ingress-nginx
-          --create-namespace
-          --set controller.config.proxy-body-size=500m
-          --set controller.config.proxy-read-timeout=300s
-          --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"="nlb"
-
-      - name: Deploy cert-manager
-        run: >
-          helm upgrade --install
-          cert-manager
-          jetstack/cert-manager
-          --version v1.16.1
-          --namespace cert-manager
-          --create-namespace
-          --set installCRDs=true
-
-      - name: Deploy cluster-autoscaler
-        run: |
-          cd terraform
-          ROLE_ARN=$(terraform output -raw cluster_autoscaler_iam_role_arn)
-          cd ..
-
-          helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler \
-            --version 9.43.0 \
-            -f helm/cluster-autoscaler/values.yaml \
-            --set-string autoDiscovery.clusterName="${CLUSTER_NAME}" \
-            --set-string extraArgs.node-group-auto-discovery="asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/${CLUSTER_NAME}" \
-            --set-string 'rbac.serviceAccount.annotations.eks\.amazonaws\.com/role-arn'="${ROLE_ARN}" \
-            --namespace kube-system
-
-      - name: Update Helm dependencies for monitoring
-        run: helm dependency update ./helm/support
-
-      - name: Deploy monitoring services
-        working-directory: ./helm
-        run: >
-          helm upgrade --install support ./support
-          -f support/values.yaml
-          --namespace support
-          --create-namespace
-          --set-string kube-prometheus-stack.grafana.ingress.hosts[0]="${{ env.GRAFANA_HOST }}"
-          --set-string kube-prometheus-stack.grafana.ingress.tls[0].hosts[0]="${{ env.GRAFANA_HOST }}"
-
-      - name: Update Helm dependencies for Zeno
-        run: helm dependency update ./helm/zeno
-
-      - name: Deploy Zeno
-        working-directory: ./helm
-        run: >
-          helm upgrade --install zeno ./zeno
-          -f zeno/values.yaml
-          -f zeno/values-staging.yaml
-          --set-string global.environment="${{ env.ENVIRONMENT }}"
-          --set-string langfuse.langfuse.ingress.hosts[0].host="${{ env.LANGFUSE_HOST }}"
-          --set-string langfuse.postgresql.auth.password="${{ secrets.DATABASE_PASSWORD }}"
-          --set-string langfuse.langfuse.nextauth.secret.value="${{ secrets.LANGFUSE_NEXTAUTH_SECRET }}"
-          --set-string langfuse.langfuse.salt.value="${{ secrets.LANGFUSE_SALT }}"
-          --set-string langfuse.s3.bucket="${{ env.LANGFUSE_BUCKET }}"
-          --set-string langfuse.s3.accessKeyId.value="${{ secrets.LANGFUSE_S3_ACCESS_KEY }}"
-          --set-string langfuse.s3.secretAccessKey.value="${{ secrets.LANGFUSE_S3_SECRET_KEY }}"
-          --set-string zeno.langfuse.host="${{ env.LANGFUSE_HOST }}"
-          --set-string zeno.api.host="${{ env.API_HOST }}"
-          --set-string zeno.api.image.tag="${{ inputs.zeno_api_sha }}"
-          --set-string zeno.streamlit.host="${{ env.STREAMLIT_HOST }}"
-          --set-string zeno.db.image.tag="${{ inputs.zeno_db_sha }}"
-          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_USER_PASSWORD="${{ secrets.LANGFUSE_INIT_USER_PASSWORD }}"
-          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY }}"
-          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY }}"
-          --set-string zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="${{ secrets.LANGFUSE_CLICKHOUSE_PASSWORD }}"
-          --set-string zeno.langfuse_secrets.REDIS_PASSWORD="${{ secrets.LANGFUSE_REDIS_PASSWORD }}"
-          --set-string zeno.env_config.LANGFUSE_HOST="https://${{ env.LANGFUSE_HOST }}"
-          --set-string zeno.env_config.EOAPI_BASE_URL="https://${{ env.EOAPI_CACHE_HOST }}"
-          --set-string zeno.env_secrets.OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
-          --set-string zeno.env_secrets.ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
-          --set-string zeno.env_secrets.NEXTJS_API_KEY="${{ secrets.NEXTJS_API_KEY }}"
-          --set-string zeno.env_secrets.AWS_ACCESS_KEY_ID="${{ secrets.S3_READONLY_AWS_ACCESS_KEY_ID }}"
-          --set-string zeno.env_secrets.AWS_SECRET_ACCESS_KEY="${{ secrets.S3_READONLY_AWS_SECRET_ACCESS_KEY }}"
-          --set-string zeno.env_secrets.GEE_SERVICE_ACCOUNT_JSON="${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}"
-          --set-string zeno.env_secrets.MAPBOX_API_TOKEN="${{ secrets.MAPBOX_API_TOKEN }}"
-          --set-string zeno.env_secrets.GFW_DATA_API_KEY="${{ secrets.GFW_DATA_API_KEY }}"
-          --set-string zeno.env_secrets.GFW_DATA_API_USER_ID="${{ secrets.GFW_DATA_API_USER_ID }}"
-          --set-string zeno.env_secrets.ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"
-          --set-string zeno.env_secrets.GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}"
-          --set-string zeno.env_secrets.COOKIE_SIGNER_SECRET_KEY="${{ secrets.COOKIE_SIGNER_SECRET_KEY }}"
-          --set-string zeno.db_secrets.POSTGRES_HOST="${{ env.STAGING_DB_HOST }}"
-          --set-string zeno.db_secrets.POSTGRES_PASSWORD="${{ secrets.DATABASE_PASSWORD }}"
-          --set-string zeno.streamlit.env_config.API_BASE_URL="https://${{ env.API_HOST }}"
-          --set-string zeno.streamlit.env_config.LOCAL_API_BASE_URL="https://${{ env.API_HOST }}"
-          --set-string zeno.streamlit.env_config.STREAMLIT_URL="https://${{ env.STREAMLIT_HOST }}"
-
-      - name: Deploy eoapi
-        working-directory: ./helm
-        run: >
-          helm upgrade --install
-          eoapi
-          eoapi/eoapi
-          --version 0.7.0
-          -f eoapi/values.yaml
-          --namespace eoapi
-          --create-namespace
-          --set-string gitSha="${{ inputs.eoapi_git_sha }}"
-          --set-string ingress.hosts[0]="${{ env.EOAPI_HOST }}"
-          --set-string ingress.hosts[1]="${{ env.EOAPI_CACHE_HOST }}"
-          --set raster.autoscaling.minReplicas=1
-          --set raster.autoscaling.maxReplicas=3

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Terraform Plan
         id: plan
         working-directory: ./terraform
-        run: terraform plan -var-file="${{ env.ENVIRONMENT }}.tfvars" -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}" -no-color -input=false
+        run: terraform plan -var="environment=${{ env.ENVIRONMENT }}" -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}" -no-color -input=false
 
       - name: Terraform Plan Status
         if: steps.plan.outcome == 'failure'

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -1,0 +1,243 @@
+name: 'Deploy Ephemeral Environment'
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment_name:
+        description: 'Name for the ephemeral environment. This will be sanitized and used for Terraform resource names.'
+        required: true
+        type: string
+      zeno_api_sha:
+        description: 'Image SHA/tag for the Zeno API image. This same image is also used by streamlit and shell.'
+        required: true
+        type: string
+      frontend_sha:
+        description: 'Optional frontend image SHA/tag. The current chart reuses the API image, so this must be blank or match zeno_api_sha.'
+        required: false
+        default: ''
+        type: string
+      zeno_db_sha:
+        description: 'Image SHA/tag for the Zeno DB migration image.'
+        required: true
+        type: string
+      eoapi_git_sha:
+        description: 'gitSha override for the eoapi chart.'
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    name: 'Deploy Ephemeral Environment'
+    runs-on: ubuntu-latest
+    # Reuse the staging GitHub environment for approvals and secrets while
+    # passing a distinct ENVIRONMENT value into Terraform and Helm.
+    environment: staging
+    concurrency:
+      group: deploy-ephemeral-${{ github.event.inputs.environment_name }}
+      cancel-in-progress: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
+      STAGING_DB_HOST: zeno-db-staging.cv2oy6g4svaz.us-east-1.rds.amazonaws.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Normalize environment name
+        run: |
+          RAW_ENVIRONMENT="${{ inputs.environment_name }}"
+          NORMALIZED_ENVIRONMENT=$(echo "${RAW_ENVIRONMENT}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+
+          NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:40}"
+          NORMALIZED_ENVIRONMENT=$(echo "${NORMALIZED_ENVIRONMENT}" | sed -E 's/^-+//; s/-+$//')
+
+          if [ -z "${NORMALIZED_ENVIRONMENT}" ]; then
+            echo "Environment name '${RAW_ENVIRONMENT}' becomes empty after sanitization."
+            exit 1
+          fi
+
+          echo "ENVIRONMENT=${NORMALIZED_ENVIRONMENT}" >> "${GITHUB_ENV}"
+          echo "TF_STATE_KEY=terraform/state/ephemeral/${NORMALIZED_ENVIRONMENT}/terraform.tfstate" >> "${GITHUB_ENV}"
+          echo "CLUSTER_NAME=zeno-${NORMALIZED_ENVIRONMENT}-cluster" >> "${GITHUB_ENV}"
+          echo "LANGFUSE_BUCKET=langfuse-${NORMALIZED_ENVIRONMENT}-bucket" >> "${GITHUB_ENV}"
+
+          echo "API_HOST=api-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
+          echo "STREAMLIT_HOST=streamlit-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
+          echo "LANGFUSE_HOST=langfuse-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
+          echo "EOAPI_HOST=eoapi-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
+          echo "EOAPI_CACHE_HOST=eoapi-cache-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
+          echo "GRAFANA_HOST=grafana-${NORMALIZED_ENVIRONMENT}.staging.globalnaturewatch.org" >> "${GITHUB_ENV}"
+
+      - name: Validate image input compatibility
+        run: |
+          FRONTEND_SHA="${{ inputs.frontend_sha }}"
+          API_SHA="${{ inputs.zeno_api_sha }}"
+
+          if [ -n "${FRONTEND_SHA}" ] && [ "${FRONTEND_SHA}" != "${API_SHA}" ]; then
+            echo "frontend_sha must be blank or match zeno_api_sha."
+            echo "The current Helm chart deploys API, streamlit, and shell from the same image tag."
+            exit 1
+          fi
+
+      - name: Configure Kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.1
+          terraform_wrapper: false
+
+      - name: Terraform Format
+        working-directory: ./terraform
+        run: terraform fmt -no-color
+
+      - name: Terraform Init
+        working-directory: ./terraform
+        run: terraform init -backend-config="key=${{ env.TF_STATE_KEY }}"
+
+      - name: Terraform Validate
+        working-directory: ./terraform
+        run: terraform validate -no-color
+
+      - name: Terraform Apply
+        working-directory: ./terraform
+        run: >
+          terraform apply
+          -var="environment=${{ env.ENVIRONMENT }}"
+          -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}"
+          -auto-approve
+
+      - name: Configure kubeconfig
+        run: aws eks update-kubeconfig --region "${{ env.AWS_REGION }}" --name "${{ env.CLUSTER_NAME }}"
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo add eoapi https://devseed.com/eoapi-k8s/
+          helm repo add autoscaler https://kubernetes.github.io/autoscaler
+          helm repo update
+
+      - name: Deploy ingress-nginx
+        run: >
+          helm upgrade --install
+          ingress-nginx
+          ingress-nginx/ingress-nginx
+          --version 4.11.3
+          --namespace ingress-nginx
+          --create-namespace
+          --set controller.config.proxy-body-size=500m
+          --set controller.config.proxy-read-timeout=300s
+          --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"="nlb"
+
+      - name: Deploy cert-manager
+        run: >
+          helm upgrade --install
+          cert-manager
+          jetstack/cert-manager
+          --version v1.16.1
+          --namespace cert-manager
+          --create-namespace
+          --set installCRDs=true
+
+      - name: Deploy cluster-autoscaler
+        run: |
+          cd terraform
+          ROLE_ARN=$(terraform output -raw cluster_autoscaler_iam_role_arn)
+          cd ..
+
+          helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler \
+            --version 9.43.0 \
+            -f helm/cluster-autoscaler/values.yaml \
+            --set-string autoDiscovery.clusterName="${CLUSTER_NAME}" \
+            --set-string extraArgs.node-group-auto-discovery="asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/${CLUSTER_NAME}" \
+            --set-string 'rbac.serviceAccount.annotations.eks\.amazonaws\.com/role-arn'="${ROLE_ARN}" \
+            --namespace kube-system
+
+      - name: Update Helm dependencies for monitoring
+        run: helm dependency update ./helm/support
+
+      - name: Deploy monitoring services
+        working-directory: ./helm
+        run: >
+          helm upgrade --install support ./support
+          -f support/values.yaml
+          --namespace support
+          --create-namespace
+          --set-string kube-prometheus-stack.grafana.ingress.hosts[0]="${{ env.GRAFANA_HOST }}"
+          --set-string kube-prometheus-stack.grafana.ingress.tls[0].hosts[0]="${{ env.GRAFANA_HOST }}"
+
+      - name: Update Helm dependencies for Zeno
+        run: helm dependency update ./helm/zeno
+
+      - name: Deploy Zeno
+        working-directory: ./helm
+        run: >
+          helm upgrade --install zeno ./zeno
+          -f zeno/values.yaml
+          -f zeno/values-staging.yaml
+          --set-string global.environment="${{ env.ENVIRONMENT }}"
+          --set-string langfuse.langfuse.ingress.hosts[0].host="${{ env.LANGFUSE_HOST }}"
+          --set-string langfuse.postgresql.auth.password="${{ secrets.DATABASE_PASSWORD }}"
+          --set-string langfuse.langfuse.nextauth.secret.value="${{ secrets.LANGFUSE_NEXTAUTH_SECRET }}"
+          --set-string langfuse.langfuse.salt.value="${{ secrets.LANGFUSE_SALT }}"
+          --set-string langfuse.s3.bucket="${{ env.LANGFUSE_BUCKET }}"
+          --set-string langfuse.s3.accessKeyId.value="${{ secrets.LANGFUSE_S3_ACCESS_KEY }}"
+          --set-string langfuse.s3.secretAccessKey.value="${{ secrets.LANGFUSE_S3_SECRET_KEY }}"
+          --set-string zeno.langfuse.host="${{ env.LANGFUSE_HOST }}"
+          --set-string zeno.api.host="${{ env.API_HOST }}"
+          --set-string zeno.api.image.tag="${{ inputs.zeno_api_sha }}"
+          --set-string zeno.streamlit.host="${{ env.STREAMLIT_HOST }}"
+          --set-string zeno.db.image.tag="${{ inputs.zeno_db_sha }}"
+          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_USER_PASSWORD="${{ secrets.LANGFUSE_INIT_USER_PASSWORD }}"
+          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY }}"
+          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY }}"
+          --set-string zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="${{ secrets.LANGFUSE_CLICKHOUSE_PASSWORD }}"
+          --set-string zeno.langfuse_secrets.REDIS_PASSWORD="${{ secrets.LANGFUSE_REDIS_PASSWORD }}"
+          --set-string zeno.env_config.LANGFUSE_HOST="https://${{ env.LANGFUSE_HOST }}"
+          --set-string zeno.env_config.EOAPI_BASE_URL="https://${{ env.EOAPI_CACHE_HOST }}"
+          --set-string zeno.env_secrets.OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
+          --set-string zeno.env_secrets.ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
+          --set-string zeno.env_secrets.NEXTJS_API_KEY="${{ secrets.NEXTJS_API_KEY }}"
+          --set-string zeno.env_secrets.AWS_ACCESS_KEY_ID="${{ secrets.S3_READONLY_AWS_ACCESS_KEY_ID }}"
+          --set-string zeno.env_secrets.AWS_SECRET_ACCESS_KEY="${{ secrets.S3_READONLY_AWS_SECRET_ACCESS_KEY }}"
+          --set-string zeno.env_secrets.GEE_SERVICE_ACCOUNT_JSON="${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}"
+          --set-string zeno.env_secrets.MAPBOX_API_TOKEN="${{ secrets.MAPBOX_API_TOKEN }}"
+          --set-string zeno.env_secrets.GFW_DATA_API_KEY="${{ secrets.GFW_DATA_API_KEY }}"
+          --set-string zeno.env_secrets.GFW_DATA_API_USER_ID="${{ secrets.GFW_DATA_API_USER_ID }}"
+          --set-string zeno.env_secrets.ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"
+          --set-string zeno.env_secrets.GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}"
+          --set-string zeno.env_secrets.COOKIE_SIGNER_SECRET_KEY="${{ secrets.COOKIE_SIGNER_SECRET_KEY }}"
+          --set-string zeno.db_secrets.POSTGRES_HOST="${{ env.STAGING_DB_HOST }}"
+          --set-string zeno.db_secrets.POSTGRES_PASSWORD="${{ secrets.DATABASE_PASSWORD }}"
+          --set-string zeno.streamlit.env_config.API_BASE_URL="https://${{ env.API_HOST }}"
+          --set-string zeno.streamlit.env_config.LOCAL_API_BASE_URL="https://${{ env.API_HOST }}"
+          --set-string zeno.streamlit.env_config.STREAMLIT_URL="https://${{ env.STREAMLIT_HOST }}"
+
+      - name: Deploy eoapi
+        working-directory: ./helm
+        run: >
+          helm upgrade --install
+          eoapi
+          eoapi/eoapi
+          --version 0.7.0
+          -f eoapi/values.yaml
+          --namespace eoapi
+          --create-namespace
+          --set-string gitSha="${{ inputs.eoapi_git_sha }}"
+          --set-string ingress.hosts[0]="${{ env.EOAPI_HOST }}"
+          --set-string ingress.hosts[1]="${{ env.EOAPI_CACHE_HOST }}"
+          --set raster.autoscaling.minReplicas=1
+          --set raster.autoscaling.maxReplicas=3

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -84,7 +84,6 @@ jobs:
       - name: Terraform Plan
         id: plan
         working-directory: ./terraform
-        if: github.event_name == 'pull_request'
         run: terraform plan -var-file="${{ env.ENVIRONMENT }}.tfvars" -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}" -no-color -input=false
 
       - name: Terraform Plan Status

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: false
     name: 'Deploy Ephemeral Environment'
     runs-on: ubuntu-latest
     environment: staging
@@ -30,9 +31,6 @@ jobs:
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
 
-          # Keep this short enough for downstream AWS name_prefix constraints.
-          # EKS derives names like zeno-<env>-cluster-cluster- and AWS caps
-          # some name_prefix values at 38 chars, leaving 16 chars for <env>.
           NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:16}"
           NORMALIZED_ENVIRONMENT=$(echo "${NORMALIZED_ENVIRONMENT}" | sed -E 's/^-+//; s/-+$//')
 
@@ -91,3 +89,116 @@ jobs:
         run: |
           echo "Terraform plan failed. See above for error details."
           exit 1
+            - name: Terraform Apply
+        working-directory: ./terraform
+        run: >
+          terraform apply
+          -var="environment=${{ env.ENVIRONMENT }}"
+          -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}"
+          -auto-approve
+
+      - name: Configure kubeconfig
+        run: aws eks update-kubeconfig --region "${{ env.AWS_REGION }}" --name "${{ env.CLUSTER_NAME }}"
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo add eoapi https://devseed.com/eoapi-k8s/
+          helm repo add autoscaler https://kubernetes.github.io/autoscaler
+          helm repo update
+
+      - name: Deploy ingress-nginx
+        run: >
+          helm upgrade --install
+          ingress-nginx
+          ingress-nginx/ingress-nginx
+          --version 4.11.3
+          --namespace ingress-nginx
+          --create-namespace
+          --set controller.config.proxy-body-size=500m
+          --set controller.config.proxy-read-timeout=300s
+          --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"="nlb"
+
+      - name: Deploy cert-manager
+        run: >
+          helm upgrade --install
+          cert-manager
+          jetstack/cert-manager
+          --version v1.16.1
+          --namespace cert-manager
+          --create-namespace
+          --set installCRDs=true
+
+      - name: Deploy cluster-autoscaler
+        run: |
+          cd terraform
+          ROLE_ARN=$(terraform output -raw cluster_autoscaler_iam_role_arn)
+          cd ..
+
+          helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler \
+            --version 9.43.0 \
+            -f helm/cluster-autoscaler/values.yaml \
+            --set-string autoDiscovery.clusterName="${CLUSTER_NAME}" \
+            --set-string extraArgs.node-group-auto-discovery="asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/${CLUSTER_NAME}" \
+            --set-string 'rbac.serviceAccount.annotations.eks\.amazonaws\.com/role-arn'="${ROLE_ARN}" \
+            --namespace kube-system
+
+      - name: Update Helm dependencies for monitoring
+        run: helm dependency update ./helm/support
+
+      - name: Deploy monitoring services
+        working-directory: ./helm
+        run: >
+          helm upgrade --install support ./support
+          -f support/values.yaml
+          --namespace support
+          --create-namespace
+          --set-string kube-prometheus-stack.grafana.ingress.hosts[0]="${{ env.GRAFANA_HOST }}"
+          --set-string kube-prometheus-stack.grafana.ingress.tls[0].hosts[0]="${{ env.GRAFANA_HOST }}"
+
+      - name: Update Helm dependencies for Zeno
+        run: helm dependency update ./helm/zeno
+
+      - name: Deploy Zeno
+        working-directory: ./helm
+        run: >
+          helm upgrade --install zeno ./zeno
+          -f zeno/values.yaml
+          -f zeno/values-staging.yaml
+          --set-string global.environment="${{ env.ENVIRONMENT }}"
+          --set zeno.db.migrate.enabled=false
+          --set-string langfuse.langfuse.ingress.hosts[0].host="${{ env.LANGFUSE_HOST }}"
+          --set-string langfuse.postgresql.auth.password="${{ secrets.DATABASE_PASSWORD }}"
+          --set-string langfuse.langfuse.nextauth.secret.value="${{ secrets.LANGFUSE_NEXTAUTH_SECRET }}"
+          --set-string langfuse.langfuse.salt.value="${{ secrets.LANGFUSE_SALT }}"
+          --set-string langfuse.s3.bucket="${{ env.LANGFUSE_BUCKET }}"
+          --set-string langfuse.s3.accessKeyId.value="${{ secrets.LANGFUSE_S3_ACCESS_KEY }}"
+          --set-string langfuse.s3.secretAccessKey.value="${{ secrets.LANGFUSE_S3_SECRET_KEY }}"
+          --set-string zeno.langfuse.host="${{ env.LANGFUSE_HOST }}"
+          --set-string zeno.api.host="${{ env.API_HOST }}"
+          --set-string zeno.streamlit.host="${{ env.STREAMLIT_HOST }}"
+          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_USER_PASSWORD="${{ secrets.LANGFUSE_INIT_USER_PASSWORD }}"
+          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY }}"
+          --set-string zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY }}"
+          --set-string zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="${{ secrets.LANGFUSE_CLICKHOUSE_PASSWORD }}"
+          --set-string zeno.langfuse_secrets.REDIS_PASSWORD="${{ secrets.LANGFUSE_REDIS_PASSWORD }}"
+          --set-string zeno.env_config.LANGFUSE_HOST="https://${{ env.LANGFUSE_HOST }}"
+          --set-string zeno.env_config.EOAPI_BASE_URL="https://${{ env.EOAPI_CACHE_HOST }}"
+          --set-string zeno.env_secrets.OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
+          --set-string zeno.env_secrets.ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
+          --set-string zeno.env_secrets.NEXTJS_API_KEY="${{ secrets.NEXTJS_API_KEY }}"
+          --set-string zeno.env_secrets.AWS_ACCESS_KEY_ID="${{ secrets.S3_READONLY_AWS_ACCESS_KEY_ID }}"
+          --set-string zeno.env_secrets.AWS_SECRET_ACCESS_KEY="${{ secrets.S3_READONLY_AWS_SECRET_ACCESS_KEY }}"
+          --set-string zeno.env_secrets.GEE_SERVICE_ACCOUNT_JSON="${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}"
+          --set-string zeno.env_secrets.MAPBOX_API_TOKEN="${{ secrets.MAPBOX_API_TOKEN }}"
+          --set-string zeno.env_secrets.GFW_DATA_API_KEY="${{ secrets.GFW_DATA_API_KEY }}"
+          --set-string zeno.env_secrets.GFW_DATA_API_USER_ID="${{ secrets.GFW_DATA_API_USER_ID }}"
+          --set-string zeno.env_secrets.ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"
+          --set-string zeno.env_secrets.GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}"
+          --set-string zeno.env_secrets.COOKIE_SIGNER_SECRET_KEY="${{ secrets.COOKIE_SIGNER_SECRET_KEY }}"
+          --set-string zeno.db_secrets.POSTGRES_PASSWORD="${{ secrets.DATABASE_PASSWORD }}"
+          --set-string zeno.streamlit.env_config.API_BASE_URL="https://${{ env.API_HOST }}"
+          --set-string zeno.streamlit.env_config.LOCAL_API_BASE_URL="https://${{ env.API_HOST }}"
+          --set-string zeno.streamlit.env_config.STREAMLIT_URL="https://${{ env.STREAMLIT_HOST }}"
+

--- a/.github/workflows/deploy-ephemeral.yaml
+++ b/.github/workflows/deploy-ephemeral.yaml
@@ -81,6 +81,12 @@ jobs:
         working-directory: ./terraform
         run: terraform validate -no-color
 
+      - name: Terraform Plan
+        id: plan
+        working-directory: ./terraform
+        if: github.event_name == 'pull_request'
+        run: terraform plan -var-file="${{ env.ENVIRONMENT }}.tfvars" -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}" -no-color -input=false
+
       - name: Terraform Plan Status
         if: steps.plan.outcome == 'failure'
         run: |

--- a/.github/workflows/destroy-ephemeral.yaml
+++ b/.github/workflows/destroy-ephemeral.yaml
@@ -1,0 +1,101 @@
+name: 'Destroy Ephemeral Environment'
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment_name:
+        description: 'Name for the ephemeral environment to destroy.'
+        required: true
+        type: string
+
+jobs:
+  destroy:
+    name: 'Destroy Ephemeral Environment'
+    runs-on: ubuntu-latest
+    environment: staging
+    concurrency:
+      group: destroy-ephemeral-${{ github.event.inputs.environment_name }}
+      cancel-in-progress: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Normalize environment name
+        run: |
+          RAW_ENVIRONMENT="${{ inputs.environment_name }}"
+          NORMALIZED_ENVIRONMENT=$(echo "${RAW_ENVIRONMENT}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+
+          NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:40}"
+          NORMALIZED_ENVIRONMENT=$(echo "${NORMALIZED_ENVIRONMENT}" | sed -E 's/^-+//; s/-+$//')
+
+          if [ -z "${NORMALIZED_ENVIRONMENT}" ]; then
+            echo "Environment name '${RAW_ENVIRONMENT}' becomes empty after sanitization."
+            exit 1
+          fi
+
+          echo "ENVIRONMENT=${NORMALIZED_ENVIRONMENT}" >> "${GITHUB_ENV}"
+          echo "TF_STATE_KEY=terraform/state/ephemeral/${NORMALIZED_ENVIRONMENT}/terraform.tfstate" >> "${GITHUB_ENV}"
+
+      - name: Skip protected environments
+        run: |
+          if [ "${{ env.ENVIRONMENT }}" = "production" ] || [ "${{ env.ENVIRONMENT }}" = "staging" ]; then
+            echo "Protected environment '${{ env.ENVIRONMENT }}' requested. Skipping destroy."
+            echo "SKIP_DESTROY=true" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Configure AWS credentials
+        if: env.SKIP_DESTROY != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        if: env.SKIP_DESTROY != 'true'
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.1
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        if: env.SKIP_DESTROY != 'true'
+        working-directory: ./terraform
+        run: terraform init -backend-config="key=${{ env.TF_STATE_KEY }}"
+
+      - name: Check for existing state
+        if: env.SKIP_DESTROY != 'true'
+        id: state_check
+        working-directory: ./terraform
+        run: |
+          if terraform state list >/dev/null 2>&1; then
+            echo "has_state=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "No Terraform state found for '${{ env.ENVIRONMENT }}'."
+            echo "has_state=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Terraform Destroy
+        if: env.SKIP_DESTROY != 'true' && steps.state_check.outputs.has_state == 'true'
+        working-directory: ./terraform
+        run: >
+          terraform destroy
+          -var="environment=${{ env.ENVIRONMENT }}"
+          -var="eoapi_db_password=${{ secrets.EOAPI_DB_PASSWORD }}"
+          -auto-approve
+
+      - name: No-op summary
+        if: env.SKIP_DESTROY == 'true' || steps.state_check.outputs.has_state != 'true'
+        run: |
+          if [ "${{ env.SKIP_DESTROY }}" = "true" ]; then
+            echo "Destroy intentionally skipped for protected environment '${{ env.ENVIRONMENT }}'."
+          else
+            echo "Nothing to destroy for '${{ env.ENVIRONMENT }}'."
+          fi

--- a/.github/workflows/destroy-ephemeral.yaml
+++ b/.github/workflows/destroy-ephemeral.yaml
@@ -32,7 +32,9 @@ jobs:
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
 
-          NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:40}"
+          # Match deploy-ephemeral.yaml so destroy targets the same state key and
+          # stays within downstream AWS name_prefix limits.
+          NORMALIZED_ENVIRONMENT="${NORMALIZED_ENVIRONMENT:0:16}"
           NORMALIZED_ENVIRONMENT=$(echo "${NORMALIZED_ENVIRONMENT}" | sed -E 's/^-+//; s/-+$//')
 
           if [ -z "${NORMALIZED_ENVIRONMENT}" ]; then

--- a/helm/zeno/templates/db-migrate-job.yaml
+++ b/helm/zeno/templates/db-migrate-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.zeno.db.migrate.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -25,3 +26,4 @@ spec:
         - name: POSTGRES_DB
           value: {{ .Values.zeno.db_secrets.POSTGRES_DB }}
       restartPolicy: Never
+{{- end }}

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -210,6 +210,8 @@ zeno:
         memory: "2Gi"
 
   db:
+    migrate:
+      enabled: true
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
       tag: 77779ef2068328f1f8667a90b41c5aeb1ea1c658

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -183,7 +183,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 43686470f159af32014219bc0392e77608b8aecc
+      tag: fb950d25e26ac665f91947fa045562723e572f32
 
   streamlit:
     host: streamlit.globalnaturewatch.org


### PR DESCRIPTION
Add ability to create ephemeral environment using the feature branch name. This will create the EKS cluster, but disables DB migrations since there's only a shared staging DB. This is a first step, where it needs to be on feature branch push to test outside of develop. For the next step, we'll decouple it from branches, and make it a manual workflow that creates a version tag.