### PR TITLE
Deploy global queries to production

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -30,7 +30,6 @@ zeno:
       limits:
         memory: "4Gi"
     image:
-      repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
       tag: ab274896517c9c6422303d7f42ff8edd4f8aa780
 
   env_config:

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -29,6 +29,9 @@ zeno:
         memory: "2Gi"
       limits:
         memory: "4Gi"
+    image:
+      repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
+      tag: ab274896517c9c6422303d7f42ff8edd4f8aa780
 
   env_config:
     LANGFUSE_HOST: https://langfuse.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -184,7 +184,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 1257d620272a3295d2683dd2fda512bcef41ed21
+      tag: 533888dbe968aec805a7a1da2b0537cf4e8f3c9d
 
   streamlit:
     host: streamlit.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -184,7 +184,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: ab274896517c9c6422303d7f42ff8edd4f8aa780
+      tag: 105c47e59ae6741eddaad3dff56272223d50a344
 
   streamlit:
     host: streamlit.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -184,7 +184,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 533888dbe968aec805a7a1da2b0537cf4e8f3c9d
+      tag: ab274896517c9c6422303d7f42ff8edd4f8aa780
 
   streamlit:
     host: streamlit.globalnaturewatch.org


### PR DESCRIPTION
Global queries will got into production, but the current project-zeno main head with the primary forest layers will stay only on staging. I.e. this has different commit shas for production vs staging.