### PR TITLE
add ENCRYPTION_KEY env var for Langfuse, fixes #158

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -209,6 +209,7 @@ jobs:
           --set zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY }}"
           --set zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="${{ secrets.LANGFUSE_CLICKHOUSE_PASSWORD }}"
           --set zeno.langfuse_secrets.REDIS_PASSWORD="${{ secrets.LANGFUSE_REDIS_PASSWORD }}"
+          --set zeno.langfuse_secrets.ENCRYPTION_KEY="${{ secrets.ENCRYPTION_KEY }}"
           --set zeno.env_secrets.OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
           --set zeno.env_secrets.ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
           --set zeno.env_secrets.NEXTJS_API_KEY="${{ secrets.NEXTJS_API_KEY }}"

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -54,6 +54,12 @@ langfuse:
           secretKeyRef:
             name: zeno-langfuse-secrets
             key: LANGFUSE_INIT_USER_PASSWORD
+      - name: ENCRYPTION_KEY
+        valueFrom:
+          secretKeyRef:
+            name: zeno-langfuse-secrets
+            key: ENCRYPTION_KEY
+            
   postgresql:
     deploy: false
     auth:
@@ -133,6 +139,7 @@ zeno:
     LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ""
     CLICKHOUSE_PASSWORD: ""
     REDIS_PASSWORD: ""
+    ENCRYPTION_KEY: ""
 
   # Database secrets  
   db_secrets:


### PR DESCRIPTION
Fixes #158 - adds a new secret called ENCRYPTION_KEY to come from secrets (I've already created and added the secrets for both staging and production), and passes it in as an env var to the Langfuse container.

cc @sunu 