### PR TITLE
dont include ENCRYPTION_KEY additionally in langfuse_secrets key

### DIFF
--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -139,7 +139,6 @@ zeno:
     LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ""
     CLICKHOUSE_PASSWORD: ""
     REDIS_PASSWORD: ""
-    ENCRYPTION_KEY: ""
 
   # Database secrets  
   db_secrets:


### PR DESCRIPTION
This should ideally fix the error from the last deploy and make sure the ENCRYPTION_KEY is actually available to the Langfuse container (the problem is we were defining this in two places which Langfuse did not like).