### PR TITLE
set encryption key as a property of langfuse and not in additionalEnv

### DIFF
--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -12,6 +12,10 @@ langfuse:
         value: ""
     salt:
       value: ""
+    encryptionKey:
+      secretKeyRef:
+        name: zeno-langfuse-secrets
+        key: ENCRYPTION_KEY
     features:
       telemetryEnabled: true
     ingress:
@@ -54,12 +58,7 @@ langfuse:
           secretKeyRef:
             name: zeno-langfuse-secrets
             key: LANGFUSE_INIT_USER_PASSWORD
-      - name: ENCRYPTION_KEY
-        valueFrom:
-          secretKeyRef:
-            name: zeno-langfuse-secrets
-            key: ENCRYPTION_KEY
-            
+
   postgresql:
     deploy: false
     auth:


### PR DESCRIPTION
Whoops - turns out Langfuse sets a default `encryptionKey` value as empty key, so it needs to be over-ridden in the right place and setting it in additionalEnv doesn't work.

This should fix.