### PR TITLE
Deploy langfuse encryption key changes to production

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -209,6 +209,7 @@ jobs:
           --set zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="${{ secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY }}"
           --set zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="${{ secrets.LANGFUSE_CLICKHOUSE_PASSWORD }}"
           --set zeno.langfuse_secrets.REDIS_PASSWORD="${{ secrets.LANGFUSE_REDIS_PASSWORD }}"
+          --set zeno.langfuse_secrets.ENCRYPTION_KEY="${{ secrets.ENCRYPTION_KEY }}"
           --set zeno.env_secrets.OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
           --set zeno.env_secrets.ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
           --set zeno.env_secrets.NEXTJS_API_KEY="${{ secrets.NEXTJS_API_KEY }}"

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -34,7 +34,7 @@ zeno:
       limits:
         memory: "4Gi"
     image:
-      tag: 1b8ee8317257b5c28fab004e1bca4342fc750f9e
+      tag: e57e2e19fb6e76b03d07f1c8a28a9ce4c2870d2e
   env_config:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -34,7 +34,7 @@ zeno:
       limits:
         memory: "4Gi"
     image:
-      tag: b88103ce963f52d16cdc4e1beef3e76bc8890761
+      tag: 6f337b8999876935d023daa1ff2ddcd145028909
   env_config:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -34,7 +34,7 @@ zeno:
       limits:
         memory: "4Gi"
     image:
-      tag: e57e2e19fb6e76b03d07f1c8a28a9ce4c2870d2e
+      tag: 7be39bedf76c035718fca2be818e5807aece71e1
   env_config:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -54,6 +54,12 @@ langfuse:
           secretKeyRef:
             name: zeno-langfuse-secrets
             key: LANGFUSE_INIT_USER_PASSWORD
+      - name: ENCRYPTION_KEY
+        valueFrom:
+          secretKeyRef:
+            name: zeno-langfuse-secrets
+            key: ENCRYPTION_KEY
+            
   postgresql:
     deploy: false
     auth:
@@ -133,6 +139,7 @@ zeno:
     LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ""
     CLICKHOUSE_PASSWORD: ""
     REDIS_PASSWORD: ""
+    ENCRYPTION_KEY: ""
 
   # Database secrets  
   db_secrets:

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -12,6 +12,10 @@ langfuse:
         value: ""
     salt:
       value: ""
+    encryptionKey:
+      secretKeyRef:
+        name: zeno-langfuse-secrets
+        key: ENCRYPTION_KEY
     features:
       telemetryEnabled: true
     ingress:
@@ -54,12 +58,7 @@ langfuse:
           secretKeyRef:
             name: zeno-langfuse-secrets
             key: LANGFUSE_INIT_USER_PASSWORD
-      - name: ENCRYPTION_KEY
-        valueFrom:
-          secretKeyRef:
-            name: zeno-langfuse-secrets
-            key: ENCRYPTION_KEY
-            
+
   postgresql:
     deploy: false
     auth:

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -139,7 +139,6 @@ zeno:
     LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ""
     CLICKHOUSE_PASSWORD: ""
     REDIS_PASSWORD: ""
-    ENCRYPTION_KEY: ""
 
   # Database secrets  
   db_secrets:


### PR DESCRIPTION
We added the ENCRYPTION_KEY env var to Langfuse on staging to be able to use the "LLM connection" feature to run tests against different LLM providers.

This PR deploys that change to production. Checklist:

 - [x] A new encryption key has been generated and added to Github Secrets -> Environment: Production -> ENCRYPTION_KEY
 - [x] Be doubly sure that this PR only affects the adding of the encryption key env var and does not change the application image on production

@sunu can I ask for a review / look - just the image tag in `values-staging` changes here, so this shouldn't affect anything else on production and I think should be safe to merge. Would just like your sign-off. Thanks!