### PR TITLE
set api and db tag values to latest, remove over-rides

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -29,8 +29,6 @@ zeno:
         memory: "2Gi"
       limits:
         memory: "4Gi"
-    image:
-      tag: 1b8ee8317257b5c28fab004e1bca4342fc750f9e
 
   env_config:
     LANGFUSE_HOST: https://langfuse.globalnaturewatch.org

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -33,8 +33,7 @@ zeno:
         memory: "2Gi"
       limits:
         memory: "4Gi"
-    image:
-      tag: 91b083f68223d51832e1bd3df136a9e7645a8178
+
   env_config:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -189,7 +189,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: e66cb17fb31119a13492c64d1c9bc543f4a3720d
+      tag: 91b083f68223d51832e1bd3df136a9e7645a8178
 
   streamlit:
     host: streamlit.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -189,6 +189,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
+      tag: e66cb17fb31119a13492c64d1c9bc543f4a3720d
 
   streamlit:
     host: streamlit.globalnaturewatch.org
@@ -217,7 +218,7 @@ zeno:
   db:
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-      tag: 2c92d53b8505265f29c9d3d2d959ef28087d088f
+      tag: f410693720b8a76f2576c07d9d40aea70de41b2b
 
 # PGBouncer configuration
 pgbouncer:


### PR DESCRIPTION
This sets the image tag values for the `api` and `db` images to their correct latest values (last change to `db` was in the `f410693` commit. Order of operations here would be:

 - Merge this to `develop` - test that the "remove whitelist table" migration runs successfully
 - Merge this to `main` - test both unapplied migrations on prod run successfully

Once we have both staging and prod on a clean slate with all migrations applied, we can go merge / test the PR to consolidate the api and db containers: https://github.com/wri/project-zeno/pull/656 so then this drift / confusion between api and db container image tags will not happen again.

cc @yellowcap 