### PR TITLE
Deploy to production

### DIFF
--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -29,8 +29,6 @@ zeno:
         memory: "2Gi"
       limits:
         memory: "4Gi"
-    image:
-      tag: 1b8ee8317257b5c28fab004e1bca4342fc750f9e
 
   env_config:
     LANGFUSE_HOST: https://langfuse.globalnaturewatch.org

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -33,8 +33,7 @@ zeno:
         memory: "2Gi"
       limits:
         memory: "4Gi"
-    image:
-      tag: 91b083f68223d51832e1bd3df136a9e7645a8178
+
   env_config:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -34,7 +34,7 @@ zeno:
       limits:
         memory: "4Gi"
     image:
-      tag: 7be39bedf76c035718fca2be818e5807aece71e1
+      tag: 91b083f68223d51832e1bd3df136a9e7645a8178
   env_config:
     LANGFUSE_HOST: https://langfuse.staging.globalnaturewatch.org
     EOAPI_BASE_URL: https://eoapi-cache-staging.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -189,7 +189,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: e66cb17fb31119a13492c64d1c9bc543f4a3720d
+      tag: 91b083f68223d51832e1bd3df136a9e7645a8178
 
   streamlit:
     host: streamlit.globalnaturewatch.org

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -218,7 +218,7 @@ zeno:
   db:
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-      tag: f410693720b8a76f2576c07d9d40aea70de41b2b
+      tag: e57e2e19fb6e76b03d07f1c8a28a9ce4c2870d2e
 
 # PGBouncer configuration
 pgbouncer:

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -189,6 +189,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
+      tag: e66cb17fb31119a13492c64d1c9bc543f4a3720d
 
   streamlit:
     host: streamlit.globalnaturewatch.org
@@ -217,7 +218,7 @@ zeno:
   db:
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-      tag: 2c92d53b8505265f29c9d3d2d959ef28087d088f
+      tag: f410693720b8a76f2576c07d9d40aea70de41b2b
 
 # PGBouncer configuration
 pgbouncer:

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -189,7 +189,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 91b083f68223d51832e1bd3df136a9e7645a8178
+      tag: a2a69021d87b80e526acdc49d04594cdd5d84996
 
   streamlit:
     host: streamlit.globalnaturewatch.org
@@ -218,7 +218,7 @@ zeno:
   db:
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-      tag: e57e2e19fb6e76b03d07f1c8a28a9ce4c2870d2e
+      tag: a2a69021d87b80e526acdc49d04594cdd5d84996
 
 # PGBouncer configuration
 pgbouncer:


### PR DESCRIPTION
Deploys latest `project-zeno` `main` to production.

In the deploy repo, this also removed the commit over-rides for staging and production and uses a commit defined in `values.yaml` so we have the same commit on both staging and prod when merged to main.

cc @yellowcap 
