### PR TITLE
Deploy db container consolidation to prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,9 @@ api:
 
 ## Database Updates
 
-When the database schema or migrations have changed:
-
-1. Open `helm/zeno/values.yaml`
-2. Under the `db` section, locate the `image` subsection
-3. Update the `tag` field with the git hash that includes the database changes
-
-Example:
-```yaml
-db:
-  image:
-    repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-    tag: 149bffadbb4d58500b13accc7eb862c4d6d08150  # Replace with new git hash
-```
-
-Note: It's important to ensure that the database migrations are compatible with the application version being deployed.
+Database migrations now ship inside the API image. Bumping `zeno.api.image.tag`
+is sufficient — a Helm `pre-install`/`pre-upgrade` Job runs `/app/db/migrate.sh`
+(`alembic upgrade head`) against `$DATABASE_URL` before the new pods roll out.
 
 ### Inspecting Logs
 

--- a/helm/zeno/templates/db-migrate-job.yaml
+++ b/helm/zeno/templates/db-migrate-job.yaml
@@ -13,15 +13,14 @@ spec:
       name: {{ .Release.Name }}-db-migrate
     spec:
       containers:
-      - name: db-migrate
-        image: "{{ .Values.zeno.db.image.repository }}:{{ .Values.zeno.db.image.tag }}"
-        env:
-        - name: POSTGRES_USER
-          value: {{ .Values.zeno.db_secrets.POSTGRES_USER }}
-        - name: POSTGRES_PASSWORD
-          value: {{ .Values.zeno.db_secrets.POSTGRES_PASSWORD }}
-        - name: POSTGRES_HOST
-          value: {{ .Values.zeno.db_secrets.POSTGRES_HOST }}
-        - name: POSTGRES_DB
-          value: {{ .Values.zeno.db_secrets.POSTGRES_DB }}
+        - name: db-migrate
+          image: "{{ .Values.zeno.api.image.repository }}:{{ .Values.zeno.api.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["/app/db/migrate.sh"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-zeno-secrets
+                  key: DATABASE_URL
       restartPolicy: Never

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -215,11 +215,6 @@ zeno:
         cpu: "1000m"
         memory: "2Gi"
 
-  db:
-    image:
-      repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno-db
-      tag: a2a69021d87b80e526acdc49d04594cdd5d84996
-
 # PGBouncer configuration
 pgbouncer:
   enabled: false

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -189,7 +189,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: a2a69021d87b80e526acdc49d04594cdd5d84996
+      tag: 09b3b109d03dd346099bddcefc78317065b30e38
 
   streamlit:
     host: streamlit.globalnaturewatch.org


### PR DESCRIPTION
This update pushes the DB container consolidation onto prod, refs https://github.com/wri/project-zeno/issues/163

This should simplify deploys when adding migrations / making db changes, not requiring keeping track of a separate image tag for the db container - now the same tag is used as the API, and the db container just runs a different command to run migrations, so things are always in sync.

This was tested in staging, and is probably good to get into prod before a lot of changes pile up to reduce any chances of confusion.

cc @yellowcap 