### PR TITLE
Add fallback models to values.yaml

### DIFF
--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -163,6 +163,8 @@ zeno:
     MODEL: "gemini-flash"
     SMALL_MODEL: "gemini-flash"
     CODING_MODEL: "gemini-3-flash-preview"
+    FALLBACK_MODELS: "gemini,gemini-flash-lite"
+    CODING_FALLBACK_MODELS: "gemini-3.1-pro-preview,gemini-2.5-pro"
     ALLOW_ANONYMOUS_CHAT: "false"
     ADMIN_USER_DAILY_QUOTA: 9999
     REGULAR_USER_DAILY_QUOTA: 10


### PR DESCRIPTION
Current fallback models are not correct, since we changed to flash for default

The current default is

```python
    coding_fallback_models: str = Field(
        default="gemini-2.5-pro,gemini-3-flash-preview",
        alias="CODING_FALLBACK_MODELS",
    )
    fallback_models: str = Field(
        default="gemini-flash,gemini-flash-lite", alias="FALLBACK_MODELS"
    )
```