### PR TITLE
chore: update eoapi version to `17.9`

### DIFF
--- a/terraform/resources/rds.tf
+++ b/terraform/resources/rds.tf
@@ -7,7 +7,7 @@ data "aws_db_instance" "zeno-db" {
 resource "aws_db_instance" "eoapi" {
   identifier = "eoapi-${var.environment}"
   engine     = "postgres"
-  engine_version = "17.5"
+  engine_version = "17.9"
   instance_class = "db.t3.small"
 
   allocated_storage = 20


### PR DESCRIPTION
Updating in response to a [failed production deployment](https://github.com/wri/project-zeno-deploy/actions/runs/27374599671/job/80895455102):
```shell
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place
Terraform will perform the following actions:
  # module.resources.aws_db_instance.eoapi will be updated in-place
  ~ resource "aws_db_instance" "eoapi" {
      ~ engine_version                        = "17.9" -> "17.5"
        id                                    = "db-QBJLPLEHIMHCJIBZDA73ZRQJWI"
        tags                                  = {
            "Environment" = "production"
            "Name"        = "eoapi-production"
        }
        # (55 unchanged attributes hidden)
    }
Plan: 0 to add, 1 to change, 0 to destroy.
module.resources.aws_db_instance.eoapi: Modifying... [id=db-QBJLPLEHIMHCJIBZDA73ZRQJWI]
╷
│ Error: updating RDS DB Instance (eoapi-production): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 55ca1c9c-1d76-4f4c-bfc4-811fd99f3b1a, api error InvalidParameterCombination: Cannot upgrade postgres from 17.9 to 17.5
│ 
│   with module.resources.aws_db_instance.eoapi,
│   on resources/rds.tf line 7, in resource "aws_db_instance" "eoapi":
│    7: resource "aws_db_instance" "eoapi" {
│ 
╵
```