### PR TITLE
add daily cronjob to ingest langfuse trace data into db

### DIFF
--- a/helm/zeno/templates/langfuse-ingest-cronjob.yaml
+++ b/helm/zeno/templates/langfuse-ingest-cronjob.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.zeno.langfuseIngest.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-langfuse-ingest
+  labels:
+    app: zeno
+    component: langfuse-ingest
+spec:
+  schedule: {{ .Values.zeno.langfuseIngest.schedule | quote }}
+  concurrencyPolicy: Forbid           # never overlap runs (watermark integrity)
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          name: {{ .Release.Name }}-langfuse-ingest
+          labels:
+            app: zeno
+            component: langfuse-ingest
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: langfuse-ingest
+              image: "{{ .Values.zeno.api.image.repository }}:{{ .Values.zeno.api.image.tag }}"
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - "uv run python src/api/cli.py ingest-langfuse-traces"
+              envFrom:
+                - configMapRef:
+                    name: {{ .Release.Name }}-zeno-config
+                - secretRef:
+                    name: {{ .Release.Name }}-zeno-secrets
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  memory: "1Gi"
+{{- end }}

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -176,6 +176,13 @@ zeno:
     enabled: true
     host: langfuse.globalnaturewatch.org
 
+  # Daily CronJob that ingests derived analytics from Langfuse traces into Postgres.
+  # Runs the `ingest-langfuse-traces` CLI in the API image; inherits DATABASE_URL,
+  # LANGFUSE_HOST and the LANGFUSE_*_KEY secrets via envFrom (no extra secrets needed).
+  langfuseIngest:
+    enabled: true
+    schedule: "0 2 * * *"   # 02:00 UTC daily, off-peak
+
   api:
     host: api.globalnaturewatch.org
     replicas: 2

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -177,8 +177,7 @@ zeno:
     host: langfuse.globalnaturewatch.org
 
   # Daily CronJob that ingests derived analytics from Langfuse traces into Postgres.
-  # Runs the `ingest-langfuse-traces` CLI in the API image; inherits DATABASE_URL,
-  # LANGFUSE_HOST and the LANGFUSE_*_KEY secrets via envFrom (no extra secrets needed).
+  # Runs the `ingest-langfuse-traces` CLI in the API image
   langfuseIngest:
     enabled: true
     schedule: "0 2 * * *"   # 02:00 UTC daily, off-peak


### PR DESCRIPTION
Adds a CronJob to run the `ingest-langfuse-traces` cli command daily to ingest langfuse traces. Adds some retry policy with a max of 5 attempts. The command should handle ingestion from the previous ingested timestamp.

@sunu would you have a moment to 👀 ?