### PR TITLE
Revert to Last Known Good - Zeno Install Causing Timeout

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -197,7 +197,6 @@ jobs:
         working-directory: ./helm
         run: >
           helm upgrade --install zeno ./zeno
-          --timeout 20m
           -f zeno/values.yaml
           -f zeno/values-${{ env.ENVIRONMENT }}.yaml
           --set langfuse.postgresql.auth.password="${{ secrets.DATABASE_PASSWORD }}"

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -37,7 +37,7 @@ zeno:
     ALLOW_ANONYMOUS_CHAT: false
     DOMAINS_ALLOWLIST: ""
     MAX_USER_SIGNUPS: 5000
-    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v6
+    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v5
 
   db_secrets:
     POSTGRES_HOST: zeno-db.cv2oy6g4svaz.us-east-1.rds.amazonaws.com

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 79d0a3719632ed1e9ae4397a11e411d9d8b39a52
+      tag: 10e44833b48463a717cb88a9b28e469804c8b498
 
   shell:
     replicas: 0


### PR DESCRIPTION
Deploy Error in GitHub Actions:
```
Run helm upgrade --install zeno ./zeno --timeout 20m -f zeno/values.yaml -f zeno/values-staging.yaml --set langfuse.postgresql.auth.*** --set langfuse.langfuse.nextauth.secret.value="***" --set langfuse.langfuse.salt.value="***" --set langfuse.s3.accessKeyId.value="" --set langfuse.s3.secretAccessKey.value="" --set zeno.langfuse_secrets.LANGFUSE_INIT_USER_PASSWORD="***" --set zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY="***" --set zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="***" --set zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="***" --set zeno.langfuse_secrets.REDIS_PASSWORD="***" --set zeno.langfuse_secrets.ENCRYPTION_KEY="***" --set zeno.env_secrets.OPENAI_API_KEY="***" --set zeno.env_secrets.ANTHROPIC_API_KEY="***" --set zeno.env_secrets.NEXTJS_API_KEY="***" --set zeno.env_secrets.AWS_ACCESS_KEY_ID="***" --set zeno.env_secrets.AWS_SECRET_ACCESS_KEY="***" --set zeno.env_secrets.GEE_SERVICE_ACCOUNT_JSON="***" --set zeno.env_secrets.MAPBOX_API_TOKEN="***" --set zeno.env_secrets.GFW_DATA_API_KEY="***" --set zeno.env_secrets.GFW_DATA_API_USER_ID="***" --set zeno.env_secrets.ELEVENLABS_API_KEY="***" --set zeno.env_secrets.GOOGLE_API_KEY="***" --set zeno.env_secrets.COOKIE_SIGNER_SECRET_KEY="***" --set zeno.db_secrets.POSTGRES_PASSWORD="***"
  helm upgrade --install zeno ./zeno --timeout 20m -f zeno/values.yaml -f zeno/values-staging.yaml --set langfuse.postgresql.auth.*** --set langfuse.langfuse.nextauth.secret.value="***" --set langfuse.langfuse.salt.value="***" --set langfuse.s3.accessKeyId.value="" --set langfuse.s3.secretAccessKey.value="" --set zeno.langfuse_secrets.LANGFUSE_INIT_USER_PASSWORD="***" --set zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY="***" --set zeno.langfuse_secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY="***" --set zeno.langfuse_secrets.CLICKHOUSE_PASSWORD="***" --set zeno.langfuse_secrets.REDIS_PASSWORD="***" --set zeno.langfuse_secrets.ENCRYPTION_KEY="***" --set zeno.env_secrets.OPENAI_API_KEY="***" --set zeno.env_secrets.ANTHROPIC_API_KEY="***" --set zeno.env_secrets.NEXTJS_API_KEY="***" --set zeno.env_secrets.AWS_ACCESS_KEY_ID="***" --set zeno.env_secrets.AWS_SECRET_ACCESS_KEY="***" --set zeno.env_secrets.GEE_SERVICE_ACCOUNT_JSON="***" --set zeno.env_secrets.MAPBOX_API_TOKEN="***" --set zeno.env_secrets.GFW_DATA_API_KEY="***" --set zeno.env_secrets.GFW_DATA_API_USER_ID="***" --set zeno.env_secrets.ELEVENLABS_API_KEY="***" --set zeno.env_secrets.GOOGLE_API_KEY="***" --set zeno.env_secrets.COOKIE_SIGNER_SECRET_KEY="***" --set zeno.db_secrets.POSTGRES_PASSWORD="***"
  shell: /usr/bin/bash -e {0}
  env:
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    ENVIRONMENT: staging
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
Error: UPGRADE FAILED: pre-upgrade hooks failed: 1 error occurred:
	* timed out waiting for the condition


Error: Process completed with exit code 1.
```

Three attempts were made and captured in these reverted commits.
