### PR TITLE
Release Integrated Alerts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -197,7 +197,6 @@ jobs:
         working-directory: ./helm
         run: >
           helm upgrade --install zeno ./zeno
-          --timeout 20m
           -f zeno/values.yaml
           -f zeno/values-${{ env.ENVIRONMENT }}.yaml
           --set langfuse.postgresql.auth.password="${{ secrets.DATABASE_PASSWORD }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -197,6 +197,7 @@ jobs:
         working-directory: ./helm
         run: >
           helm upgrade --install zeno ./zeno
+          --timeout 20m
           -f zeno/values.yaml
           -f zeno/values-${{ env.ENVIRONMENT }}.yaml
           --set langfuse.postgresql.auth.password="${{ secrets.DATABASE_PASSWORD }}"

--- a/helm/zeno/templates/langfuse-ingest-cronjob.yaml
+++ b/helm/zeno/templates/langfuse-ingest-cronjob.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.zeno.langfuseIngest.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-langfuse-ingest
+  labels:
+    app: zeno
+    component: langfuse-ingest
+spec:
+  schedule: {{ .Values.zeno.langfuseIngest.schedule | quote }}
+  concurrencyPolicy: Forbid           # never overlap runs (watermark integrity)
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          name: {{ .Release.Name }}-langfuse-ingest
+          labels:
+            app: zeno
+            component: langfuse-ingest
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: langfuse-ingest
+              image: "{{ .Values.zeno.api.image.repository }}:{{ .Values.zeno.api.image.tag }}"
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - "uv run python src/api/cli.py ingest-langfuse-traces"
+              envFrom:
+                - configMapRef:
+                    name: {{ .Release.Name }}-zeno-config
+                - secretRef:
+                    name: {{ .Release.Name }}-zeno-secrets
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  memory: "1Gi"
+{{- end }}

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -37,7 +37,7 @@ zeno:
     ALLOW_ANONYMOUS_CHAT: false
     DOMAINS_ALLOWLIST: ""
     MAX_USER_SIGNUPS: 5000
-    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v6
+    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v5
 
   db_secrets:
     POSTGRES_HOST: zeno-db.cv2oy6g4svaz.us-east-1.rds.amazonaws.com

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -40,7 +40,7 @@ zeno:
     ALLOW_ANONYMOUS_CHAT: false
     DOMAINS_ALLOWLIST: ""
     MAX_USER_SIGNUPS: 5000
-    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v5
+    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v7
 
   db_secrets:
     POSTGRES_HOST: zeno-db.cv2oy6g4svaz.us-east-1.rds.amazonaws.com

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -37,7 +37,7 @@ zeno:
     ALLOW_ANONYMOUS_CHAT: false
     DOMAINS_ALLOWLIST: ""
     MAX_USER_SIGNUPS: 5000
-    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v5
+    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v6
 
   db_secrets:
     POSTGRES_HOST: zeno-db.cv2oy6g4svaz.us-east-1.rds.amazonaws.com

--- a/helm/zeno/values-production.yaml
+++ b/helm/zeno/values-production.yaml
@@ -17,6 +17,9 @@ zeno:
 
   api:
     host: api.globalnaturewatch.org
+    image:
+      repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
+      tag: 0c7ed1a5a75eadab4bd1e38f88f9cdfcc8cef622
     autoscaling:
       enabled: true
       minReplicas: 3

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -45,7 +45,7 @@ zeno:
     DOMAINS_ALLOWLIST: ""
     MAX_USER_SIGNUPS: 5000
     GNW_STAGE: staging
-    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v6
+    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v7
 
   db_secrets:
     POSTGRES_HOST: zeno-db-staging.cv2oy6g4svaz.us-east-1.rds.amazonaws.com

--- a/helm/zeno/values-staging.yaml
+++ b/helm/zeno/values-staging.yaml
@@ -45,7 +45,7 @@ zeno:
     DOMAINS_ALLOWLIST: ""
     MAX_USER_SIGNUPS: 5000
     GNW_STAGE: staging
-    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v5
+    DATASET_EMBEDDINGS_DB: gnw-dataset-index-gemini-v6
 
   db_secrets:
     POSTGRES_HOST: zeno-db-staging.cv2oy6g4svaz.us-east-1.rds.amazonaws.com

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 581bf57a56d2fdb8a0f9737f80dee97b77b4e741
+      tag: 10e44833b48463a717cb88a9b28e469804c8b498
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: dc166b425cb68b5e8af57dab18c4170b46d581e1
+      tag: d4929c09a05a0079513af46ad1a3db2fff60e201
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: ec6f061260dad8f0fa936d79e61b6482e7e6cc90
+      tag: 6daf363b85968d19b18ef02a9a776a6a8ed748a3
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 79d0a3719632ed1e9ae4397a11e411d9d8b39a52
+      tag: 10e44833b48463a717cb88a9b28e469804c8b498
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -193,7 +193,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: e54315a70276dc7f546e9444f624162ad8d534d2
+      tag: ce12e0ba9b8a2f585a2492db7bdba0f3922c1f54
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 62347d1577c665307e0f500c759e055ef238dbad
+      tag: 64e846364a0b8dbc2f9447a7ef4eb7a448f51a69
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -176,6 +176,13 @@ zeno:
     enabled: true
     host: langfuse.globalnaturewatch.org
 
+  # Daily CronJob that ingests derived analytics from Langfuse traces into Postgres.
+  # Runs the `ingest-langfuse-traces` CLI in the API image; inherits DATABASE_URL,
+  # LANGFUSE_HOST and the LANGFUSE_*_KEY secrets via envFrom (no extra secrets needed).
+  langfuseIngest:
+    enabled: true
+    schedule: "0 2 * * *"   # 02:00 UTC daily, off-peak
+
   api:
     host: api.globalnaturewatch.org
     replicas: 2

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 2aa76b5df065dd3b46644072954fc6adb14f7918
+      tag: dd91e2c2b8d007307fdbad3c69fba735805cc343
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -193,7 +193,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 30debc69789a0ce4f52b692614fbf5b8372676f5
+      tag: 581bf57a56d2fdb8a0f9737f80dee97b77b4e741
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -193,7 +193,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 6ca3a619b7b89b3657d2aea29dca933130d46608
+      tag: 30debc69789a0ce4f52b692614fbf5b8372676f5
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -177,8 +177,7 @@ zeno:
     host: langfuse.globalnaturewatch.org
 
   # Daily CronJob that ingests derived analytics from Langfuse traces into Postgres.
-  # Runs the `ingest-langfuse-traces` CLI in the API image; inherits DATABASE_URL,
-  # LANGFUSE_HOST and the LANGFUSE_*_KEY secrets via envFrom (no extra secrets needed).
+  # Runs the `ingest-langfuse-traces` CLI in the API image
   langfuseIngest:
     enabled: true
     schedule: "0 2 * * *"   # 02:00 UTC daily, off-peak

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 943ec4c190d519a8777fd0b84f83a5c344976d7e
+      tag: 05287719633c17ee7473eb15b13fb593f52d4b02
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -193,7 +193,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: ce12e0ba9b8a2f585a2492db7bdba0f3922c1f54
+      tag: 80792b58737c077f659a4b9dbf440c1f9fde3439
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 10e44833b48463a717cb88a9b28e469804c8b498
+      tag: 183e6836364d5fe62141f6318567347b0261eb9f
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 10e44833b48463a717cb88a9b28e469804c8b498
+      tag: 79d0a3719632ed1e9ae4397a11e411d9d8b39a52
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 6daf363b85968d19b18ef02a9a776a6a8ed748a3
+      tag: 0e82624197f52d72a2cde82f9d56a1fe5a97d7f4
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 183e6836364d5fe62141f6318567347b0261eb9f
+      tag: 089cab6f400fc782f4b8fa5100b502edbf68b2f7
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 04d7a004fcf8317284613ff41a40af8c1def7ee2
+      tag: fb4a1222069519447510127a29c7769d6e765344
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 083ee8b4acf0b3668f9a55338c872c405337b13e
+      tag: 57aa4ef3f300860f73a8283e16308c72e37f89bb
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 7795848214e770ab31fcc63d7ce131147a8d07f7
+      tag: ec6f061260dad8f0fa936d79e61b6482e7e6cc90
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 05287719633c17ee7473eb15b13fb593f52d4b02
+      tag: 62347d1577c665307e0f500c759e055ef238dbad
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 1573d1edf20ce9617bd451735335cb5a4cc44f48
+      tag: 7a0f7b62234e136b8c82e79123ad6f5ea0f62464
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 089cab6f400fc782f4b8fa5100b502edbf68b2f7
+      tag: 7795848214e770ab31fcc63d7ce131147a8d07f7
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: d4929c09a05a0079513af46ad1a3db2fff60e201
+      tag: 04d7a004fcf8317284613ff41a40af8c1def7ee2
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: f4563c59ea0cad9e4d5ebdea53a18213505db55e
+      tag: 2aa76b5df065dd3b46644072954fc6adb14f7918
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -193,7 +193,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 80792b58737c077f659a4b9dbf440c1f9fde3439
+      tag: 6ca3a619b7b89b3657d2aea29dca933130d46608
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: dd91e2c2b8d007307fdbad3c69fba735805cc343
+      tag: 083ee8b4acf0b3668f9a55338c872c405337b13e
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 0e82624197f52d72a2cde82f9d56a1fe5a97d7f4
+      tag: 22465582a050860a100af091fb3d586da2710d80
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: add9156321a8b0c2b97a73e8dfa858e550f9f2ec
+      tag: dc166b425cb68b5e8af57dab18c4170b46d581e1
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 57aa4ef3f300860f73a8283e16308c72e37f89bb
+      tag: add9156321a8b0c2b97a73e8dfa858e550f9f2ec
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 64e846364a0b8dbc2f9447a7ef4eb7a448f51a69
+      tag: 1573d1edf20ce9617bd451735335cb5a4cc44f48
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: 22465582a050860a100af091fb3d586da2710d80
+      tag: f4563c59ea0cad9e4d5ebdea53a18213505db55e
 
   shell:
     replicas: 0

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -199,7 +199,7 @@ zeno:
         memory: "4Gi"
     image:
       repository: public.ecr.aws/b7u8b0a6/project-zeno/zeno
-      tag: fb4a1222069519447510127a29c7769d6e765344
+      tag: 943ec4c190d519a8777fd0b84f83a5c344976d7e
 
   shell:
     replicas: 0


### PR DESCRIPTION
# Deploy release-2026-08-05 (project-zeno tip `0c7ed1a5`)

## Summary

Points production at `project-zeno`'s `release-2026-08-05` branch (tip `0c7ed1a5`, version `2026.7.1`) and brings the dataset-selection embeddings index up to date with the new dataset that branch ships. Two commits, both scoped to `helm/zeno/values-production.yaml` only — `values.yaml` (staging's base config) is untouched, so staging keeps running whatever it's already running.

This release does **not** come from a normal `main` merge — the [plan for it](https://github.com/wri/project-zeno/pull/786) documents that `release-2026-08-05` predates several infra files `main` has since renamed, so the branch carries its own release-only CI-enablement commit plus three cherry-picks, and ships straight from `docker-build-release-branch.yml`'s SHA-tagged image rather than `docker-build.yml`'s `main`-tagged one.

## Release content (from the release plan)

Four things ship live by default, one behind the `experimental` flag:

- **Machine-user key scopes** (#721) — additive `scopes` column on `machine_user_keys` (Alembic `e0e882fba200`, safe/backward-compatible).
- **Insights narrative generator refactor** (#724/#726) — standalone LLM call for narrative text instead of folding it into the analyst tool call. Highest blast-radius change in the release; touches the path every insight request goes through.
- **Integrated Alerts dataset** (#725/#727/#732, cherry-picked #740) — new `dataset_id: 11` combining DIST-ALERT/GLAD-L/GLAD-S2/RADD, auto-discovered from `integrated_alerts.yml`. **This is the dataset the embeddings bump below is for.**
- **`inspect_view_context` tool** — experimental-profile only, no effect on default users.

Full commit list, risk assessment, and rollback plan are in the [release plan doc](https://github.com/wri/project-zeno/pull/786); not duplicated here.

## Why the embeddings bump — investigation findings

### Tools Tests failed on the actual deploy tip, contradicting the plan

The release plan's pre-deploy checklist assumes CI re-verification on `0c7ed1a5` is "a formality" since Lint/Unit Tests/CalVer/Docker-build were already green pre-reorder. In practice, **Tools Tests had never once completed on this branch** — every earlier push shows it as `cancelled`. On `0c7ed1a5` it ran to completion for the first time and **failed**, 6 tests:

- 4 failures: generic "forest disturbance" queries (no breakdown requested) that should route to **Integrated Alerts** are instead routing to **DIST-ALERT** — the inverse of the routing behavior `77958482`'s `selection_hints` retune was supposed to produce, and contrary to the plan's own smoke tests #5/#5b.
- 2 failures: LLM-judge language-detection mismatches (English returned instead of Spanish/Portuguese) — looks like pre-existing flakiness, unrelated to this release.

Broader context: Tools Tests last **passed** on `2026-05-28` (PR "PZB-913: Suggest datasets instead of always choosing one") — every run since, across a dozen+ unrelated PRs, has been `failure` or `cancelled`. So this isn't "the release just broke a clean pipeline" — it's a chronically red workflow. That doesn't make the 4 forest-disturbance failures noise, though: they're new, specific, and land exactly on the feature this release adds.

### Root cause: production's dataset embeddings index predates the new dataset

`pick_dataset` (`src/agent/subagents/pick_dataset/tool.py`) resolves datasets in two stages:

1. **Stage 1 (RAG retrieval)** — embeds the query and does similarity search against a pre-built `InMemoryVectorStore` index, named by `DATASET_EMBEDDINGS_DB`, loaded from `data/<name>` in the running pod (synced in by the `s3-data-sync` init container from `s3://zeno-static-data`). Returns only the **top-5** nearest datasets.
2. **Stage 2 (LLM selection)** — an LLM picks among *only those 5 candidates*, reading each one's `selection_hints` live from the catalog YAML at request time.

So catalog edits like `77958482`'s `selection_hints` retune take effect immediately for stage 2 — but only for datasets stage 1 even surfaces. Production's index was still `gnw-dataset-index-gemini-v5`, built **before `integrated_alerts.yml` existed**, so it has no embedding for dataset 11 at all. Stage 1 can never return Integrated Alerts as a candidate, so stage 2 always falls back to DIST-ALERT for disturbance queries — regardless of how correct the retuned hints are.

```mermaid
flowchart TB
    Q["Query: 'forest disturbance alerts\nin Protected Areas in Ucayali, Peru'"]
    Q --> S1

    subgraph S1["Stage 1 — RAG retrieval (embedding similarity)"]
        direction TB
        IDX[("DATASET_EMBEDDINGS_DB\nindex loaded from data/&lt;name&gt;")]
        TOP5["Top-5 nearest datasets"]
        IDX --> TOP5
    end

    S1 --> S2

    subgraph S2["Stage 2 — LLM selection"]
        direction TB
        HINTS["Reads selection_hints live\nfrom catalog YAML"]
        PICK["Picks best match\namong the 5 candidates"]
        HINTS --> PICK
    end

    S2 --> RESULT

    subgraph RESULT["Result depends on index freshness"]
        direction LR
        BAD["v5 index (pre-Integrated Alerts):\nInt. Alerts never in top-5\n→ falls back to DIST-ALERT"]
        GOOD["v7 index (post both catalog commits):\nInt. Alerts correctly retrieved\n→ selection_hints route it right"]
    end

    style BAD fill:#fca5a5,stroke:#7f1d1d,color:#7f1d1d
    style GOOD fill:#86efac,stroke:#14532d,color:#14532d
```

### Timeline reconstructed from `values-production.yaml` / `values-staging.yaml` history

| Date | Event | Staging index | Production index |
|---|---|---|---|
| 2026-06-29 | `30debc69` adds `integrated_alerts.yml` | bumped `v5 → v6` same day | — |
| 2026-07-01 | jterry64 bumps prod `v5 → v6` (`a04fc8c`) | — | bumped, then **reverted same day** (`c4b5a32`, by me) — production's app code didn't have Integrated Alerts yet at that point, so the index would have pointed at nothing |
| 2026-07-06 | `77958482` retunes `selection_hints` on both catalog entries | bumped `v6 → v7` (`0a66f877`, "Int alerts embeddings fix") | never touched again |
| 2026-08-04 (this PR) | production image pinned to release tip `0c7ed1a5` | still `v7` | bumped **`v5 → v7`** |

`v7` is the right target, not `v6`: it was built right after the `selection_hints` retune this release also cherry-picks (`77958482`), and staging hasn't needed to move past it since — so it matches this release's catalog state exactly.

## Pre-merge checklist

- [ ] Confirm `s3://zeno-static-data/gnw-dataset-index-gemini-v7` exists (see verification gap above)
- [ ] Confirm CI is actually green on `0c7ed1a5` — Tools Tests currently fails; decide whether the 4 routing failures are acceptable to ship given this fix, or whether `selection_hints`/routing needs further work first
- [ ] Confirm `docker-build-release-branch.yml` pushed `public.ecr.aws/b7u8b0a6/project-zeno/zeno:0c7ed1a5a75eadab4bd1e38f88f9cdfcc8cef622` (full SHA, not the short one)
- [ ] Run `alembic upgrade head` (`e0e882fba200`) before this deploys — additive, backward-compatible, safe to run ahead of the image swap
- [ ] Notify #eng-oncall that Integrated Alerts goes live with this deploy — no flag to roll it back except a redeploy

## Rollback

Per the release plan: revert `image.tag` (and, per this PR, `DATASET_EMBEDDINGS_DB`) back to what they were before this deploy — no rebuild needed, old image and old index stay in ECR/S3. The only schema change (`scopes` column) is additive and safe to leave in place even if the app is rolled back.

## Note on branch state

These two commits currently sit on top of `develop` (pushed there in the course of this work). This repo's normal release pattern merges `develop` → `main` via PR to trigger a production deploy (`main` push = production, per `deploy.yaml` and `README.md`), so the natural next step is a PR from `develop` into `main` carrying these two commits forward.