### PR TITLE
Wire WRI_BEARER_TOKEN secret to main/production deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -222,6 +222,7 @@ jobs:
           --set zeno.env_secrets.ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"
           --set zeno.env_secrets.GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}"
           --set zeno.env_secrets.COOKIE_SIGNER_SECRET_KEY="${{ secrets.COOKIE_SIGNER_SECRET_KEY }}"
+          --set zeno.env_secrets.WRI_BEARER_TOKEN="${{ secrets.WRI_BEARER_TOKEN }}"
           --set zeno.db_secrets.POSTGRES_PASSWORD="${{ secrets.DATABASE_PASSWORD }}"
       # Deploy eoapi
       - name: Deploy eoapi

--- a/helm/zeno/values.yaml
+++ b/helm/zeno/values.yaml
@@ -130,6 +130,7 @@ zeno:
     AWS_SECRET_ACCESS_KEY: ""
     COOKIE_SIGNER_SECRET_KEY: ""
     GEE_SERVICE_ACCOUNT_JSON: ""
+    WRI_BEARER_TOKEN: ""
 
   # Langfuse-specific secrets
   langfuse_secrets:


### PR DESCRIPTION
## Why

`main`'s `project-zeno` app code now sends `Authorization: Bearer $WRI_BEARER_TOKEN` on every GFW Analytics API call (introduced alongside the new LGMS dataset in `f9cf409c`, but shared by the same handler behind DIST-ALERT, Integrated Alerts, Natural Lands, Tree Cover Loss/Gain, and most other analytics-backed datasets — not just LGMS).

`develop` already wires this secret through end-to-end (`0ca2cb8`, "Pass WRI_BEARER_TOKEN secret"). `main` — which drives the `production` environment per this workflow's `ENVIRONMENT` selector — never picked up that change. Promoting `main`'s app code to production as-is would silently send unauthenticated analytics requests for most pull-data-driven datasets.

## What

Same two-line pattern as every other `env_secrets` entry:
- `helm/zeno/values.yaml`: add `WRI_BEARER_TOKEN: ""` placeholder to `zeno.env_secrets`.
- `.github/workflows/deploy.yaml`: add `--set zeno.env_secrets.WRI_BEARER_TOKEN="${{ secrets.WRI_BEARER_TOKEN }}"` to the `helm upgrade` invocation.

No template/`deployment.yaml` changes needed — `secrets.yaml` generically loops over every `env_secrets` key into the K8s Secret, and the pod's `envFrom: secretRef` injects all of them automatically.

## Secrets

`WRI_BEARER_TOKEN` already exists as a **repository-level** GitHub Actions secret (added 2026-08-06, currently only referenced by `develop`). Repo-level secrets are available to any job that declares an `environment:` (production/staging) unless overridden at the environment level — neither environment currently defines its own `WRI_BEARER_TOKEN`, so no further GitHub configuration is needed; this PR alone is sufficient.

## Test plan

- [ ] Confirm `helm template` renders the new key without error
- [ ] Confirm on next deploy that the `WRI_BEARER_TOKEN` env var is present in the running `zeno-api` pod (not empty)
- [ ] Confirm an analytics-API-backed `pull_data` call (e.g. DIST-ALERT) succeeds in the target environment post-deploy